### PR TITLE
Add elevation and default color to AppBar

### DIFF
--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -23,7 +23,7 @@ const DesktopMain: React.FC = () => {
 
     return <>
         <Box sx={{flexGrow: 1}}>
-            <AppBar position="static">
+            <AppBar position="static" variant="elevation" color="default">
                 <Toolbar>
                     <IconButton size="large" edge="start" color="inherit" aria-label="menu" sx={{mr: 2}}>
                         <Menu />


### PR DESCRIPTION
This PR adds the default theme color to the AppBar. Now, all the elements can easily be read, but the application looks crazy-white in the light mode.

@JesJehle, not sure about the right approach here: change the default color of the light theme or use a custom color here? Maybe any of the other theme colors fits better for both modes?