### PR TITLE
Layer switch

### DIFF
--- a/src/appState/backendSignals.ts
+++ b/src/appState/backendSignals.ts
@@ -2,9 +2,9 @@
  * The backend signals are used to communicate with the backend and reflect the current state of the backend.
  * To ease things a bit, I put all the firebase stuff in here as well.
  */
-import { computed, effect, signal } from "@preact/signals-react";
+import { computed, signal } from "@preact/signals-react";
 import { initializeApp } from "firebase/app"
-import { getAuth, User, signInAnonymously  } from "firebase/auth"
+//import { getAuth, User, signInAnonymously  } from "firebase/auth"
 import { parse } from "papaparse"
 
 // Your web app's Firebase configuration

--- a/src/appState/mapSignals.ts
+++ b/src/appState/mapSignals.ts
@@ -1,4 +1,5 @@
-import { signal, computed } from "@preact/signals-react"
+import { signal, computed, effect } from "@preact/signals-react"
+import { referenceFeature } from "./statisticsSignals"
 
 export interface ViewState {
     longitude: number,
@@ -22,5 +23,23 @@ export const center = computed(() => {
     return {
         lng: viewState.value.longitude,
         lat: viewState.value.latitude
+    }
+})
+
+// layers and their visibility
+export const layerVisibility = signal<{[layerId: string]: "none" | "visible"}>({})
+
+// add effects for aout-disabling layers
+effect(() => {
+    if (!referenceFeature.value) {
+        const { referenceArea, ...others } = layerVisibility.peek()
+        layerVisibility.value = others 
+    }
+    // otherwise if it did not exist before, add it
+    else if (!Object.keys(layerVisibility.peek()).includes("referenceArea")) {
+        layerVisibility.value = {
+            ...layerVisibility.peek(),
+            referenceArea: "visible"
+        }
     }
 })

--- a/src/appState/statisticsSignals.ts
+++ b/src/appState/statisticsSignals.ts
@@ -5,7 +5,6 @@ import { treeLocations } from "./treeLineSignals"
 import area from "@turf/area"
 import convex from "@turf/convex"
 import buffer from "@turf/buffer"
-import { layerVisibility } from "./mapSignals"
 
 // update a convex hull for all treeLocations, whenever they change
 const treeLocationHull = computed(() => convex(treeLocations.value))

--- a/src/appState/statisticsSignals.ts
+++ b/src/appState/statisticsSignals.ts
@@ -5,6 +5,7 @@ import { treeLocations } from "./treeLineSignals"
 import area from "@turf/area"
 import convex from "@turf/convex"
 import buffer from "@turf/buffer"
+import { layerVisibility } from "./mapSignals"
 
 // update a convex hull for all treeLocations, whenever they change
 const treeLocationHull = computed(() => convex(treeLocations.value))

--- a/src/components/MainMap/MapLayerSwitchButton.tsx
+++ b/src/components/MainMap/MapLayerSwitchButton.tsx
@@ -1,0 +1,36 @@
+import { Box, Fab, Popover } from "@mui/material"
+import { Layers, Close } from "@mui/icons-material"
+import { useSignal } from "@preact/signals-react"
+import { useRef } from "react"
+import MapLayerSwitchMenu from "./MapLayerSwitchMenu"
+
+const MapLayerSwitchButton: React.FC = () => {
+    // anchor ref for the popover
+    const anchorRef = useRef<HTMLButtonElement>(null)
+
+    // component signal to control the popover state
+    const open = useSignal<boolean>(false)
+
+    // control for the popover state
+    const toggleLayerMenu = () => {
+        open.value = !open.peek()
+    }
+    return <>
+        <Fab ref={anchorRef} size="medium" color="default" aria-label="Show map layers" sx={{ position: 'fixed', bottom: 25, right: 10}} onClick={toggleLayerMenu}>
+            { open.value ? <Close /> : <Layers /> }
+        </Fab>
+        <Popover 
+            open={open.value}
+            anchorEl={anchorRef.current}
+            anchorOrigin={{vertical: 'top', horizontal: 'left'}}
+            transformOrigin={{vertical: 'bottom', horizontal: 'left'}}
+            onClose={() => open.value = false}
+        >
+            <Box minWidth={150}>
+                <MapLayerSwitchMenu />  
+            </Box>
+        </Popover>
+    </>
+}
+
+export default MapLayerSwitchButton

--- a/src/components/MainMap/MapLayerSwitchMenu.tsx
+++ b/src/components/MainMap/MapLayerSwitchMenu.tsx
@@ -1,0 +1,23 @@
+import { MenuItem, MenuList, Switch, Typography } from "@mui/material"
+import { layerVisibility } from "../../appState/mapSignals"
+
+const MapLayerSwitchMenu: React.FC = () => {
+    // function to toggle a layer in the global visibility state
+    const toggleLayer = (layerName: string) => {
+        // check the current state of the layer
+        const visible = layerVisibility.peek()[layerName] === "visible" || false
+        layerVisibility.value = {...layerVisibility.value, [layerName]: visible ? "none" : "visible"}
+    }
+
+    return <>
+        <MenuList sx={{width: '100%'}}>
+            <MenuItem disabled={!layerVisibility.value.referenceArea} onClick={() => toggleLayer('referenceArea')}>
+                <Typography>Referenzfläche einblenden</Typography>
+                <Switch checked={layerVisibility.value.referenceArea === "visible"} />
+            </MenuItem>
+            
+        </MenuList>
+    </>
+}
+
+export default MapLayerSwitchMenu

--- a/src/components/MainMap/ReferenceAreaSource.tsx
+++ b/src/components/MainMap/ReferenceAreaSource.tsx
@@ -2,11 +2,19 @@ import { Layer, Source } from "react-map-gl"
 import { referenceFeature } from "../../appState/statisticsSignals"
 import { FillPaint, LinePaint } from "mapbox-gl"
 import { useIntegraTheme } from "../../context/IntegraThemeContext"
+import { useSignal, useSignalEffect } from "@preact/signals-react"
+import { layerVisibility } from "../../appState/mapSignals"
 
 
 const ReferenceAreaSource: React.FC = () => {
     // subscribe to dark mode
     const theme = useIntegraTheme()
+
+    // extract the visibility of the reference area from the global visibility state
+    const visibility = useSignal<"none" | "visible">("none")
+    useSignalEffect(() => {
+        visibility.value = layerVisibility.value.referenceArea || "none"
+    })
 
     return <>
         <Source id="reference-area" type="geojson" data={referenceFeature.value ? referenceFeature.value : {type: "FeatureCollection", features: []}} generateId>
@@ -18,6 +26,7 @@ const ReferenceAreaSource: React.FC = () => {
                     'fill-color': theme.palette.secondary.dark,
                     'fill-opacity': 0.2
                 } as FillPaint}
+                layout={{visibility: visibility.value}}
             />
             <Layer 
                 id="reference-area-outline-layer"
@@ -27,6 +36,7 @@ const ReferenceAreaSource: React.FC = () => {
                     'line-color': theme.palette.secondary.dark,
                     'line-width': 4
                 } as LinePaint}
+                layout={{visibility: visibility.value}}
             />
         </Source>
     </>

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -14,6 +14,7 @@ import TreeLineTooltip from "../components/MainMap/TreeLineTooltip"
 import ReferenceAreaSource from "../components/MainMap/ReferenceAreaSource"
 import ProjectSelect from "../components/ProjectSelect"
 import { useSignal } from "@preact/signals-react"
+import MapLayerSwitchButton from "../components/MainMap/MapLayerSwitchButton"
 
 
 
@@ -88,6 +89,7 @@ const DesktopMain: React.FC = () => {
                 <DrawControl />
                 <TreeLineSource />
                 <ReferenceAreaSource />
+                <MapLayerSwitchButton />
                 <TreeLineTooltip />
             </MainMap>
         </Box>


### PR DESCRIPTION
@JesJehle, this is my approach to #40 and #18

closes #18

The logic can be replicated for more layer. I chose a `<Popover>` because it works good on Desktop. This implementation is already using two components and a global state. This way, we can easily put the Popover *content* somewhere else on mobile while adding other actions that can disable the layer visibility (ie, if polygons are shown for effect zones...)