### PR TITLE
Add Simulation skeleton

### DIFF
--- a/src/appState/simulationSignals.ts
+++ b/src/appState/simulationSignals.ts
@@ -1,0 +1,23 @@
+/**
+ * Simulations are used to change the state of the treeLine in place.
+ * 
+ * A simulation is controlled by a step since the start of the simulation
+ * and is measured in years.
+ */
+
+import { computed, signal } from "@preact/signals-react";
+
+// the iteration is too important, so we make it private to this module
+const step = signal<number>(0);
+
+// public read-only access to the duration - we could use a better name here
+export const simulationStep = computed<number>(() => step.value)
+
+// public handler to set the simulation duration directly
+export const setSimulationStep = (newStep: number) => {
+    // TODO: I implement some hard-coded rules here
+    // it is an INTEGER between 0 100
+    const validatedStep = Math.max(0, Math.min(Math.round(Number(newStep)), 100))
+
+    step.value = validatedStep
+}

--- a/src/appState/simulationSignals.ts
+++ b/src/appState/simulationSignals.ts
@@ -5,19 +5,48 @@
  * and is measured in years.
  */
 
-import { computed, signal } from "@preact/signals-react";
+import { batch, computed, effect, signal } from "@preact/signals-react";
+import { updateAllLineAges } from "./treeLineSignals";
 
 // the iteration is too important, so we make it private to this module
-const step = signal<number>(0);
+const step = signal<number>(0)
+const previousStep = signal<number>(-1)
+
 
 // public read-only access to the duration - we could use a better name here
-export const simulationStep = computed<number>(() => step.value)
+interface SimulationStep {
+    current: number,
+    previous: number
+}
+// the simulation step updates only if step changes, as it is updated in a batch with previousStep
+export const simulationStep = computed<SimulationStep>(() => {
+    return {
+        current: step.value,
+        previous: previousStep.peek()
+    }
+})
 
 // public handler to set the simulation duration directly
 export const setSimulationStep = (newStep: number) => {
     // TODO: I implement some hard-coded rules here
     // it is an INTEGER between 0 100
     const validatedStep = Math.max(0, Math.min(Math.round(Number(newStep)), 100))
-
-    step.value = validatedStep
+    const previous = step.peek()
+    
+    // only update if the step has changed
+    if (validatedStep === previous) return
+    
+    batch(() => {
+        step.value = validatedStep
+        previousStep.value = previous
+    })
 }
+
+// this is one of the tests right now: try to only update the treeLine as an effect of a changing step
+effect(() => {
+    // check if we need to decrease or increase the treeAge
+    const ageChange = simulationStep.value.current - simulationStep.value.previous
+
+    // update all treeLines accordingly
+    const newTreeLines = updateAllLineAges(ageChange)
+})

--- a/src/appState/treeLineSignals.ts
+++ b/src/appState/treeLineSignals.ts
@@ -27,6 +27,7 @@ export const drawState = signal<DrawState>(DrawState.OFF)
 // main signal to hold the treeLine data
 const rawTreeLineFeatures = signal<TreeLine["features"]>([])
 export const readOnlyRawTreeLineFeatures = computed(() => rawTreeLineFeatures.value)
+export const hasData = computed<boolean>(() => rawTreeLineFeatures.value.length > 0)
 
 // we need the treeLineFeatues twice, as some of the attributes depend on the treeLocation
 // which is a circular dependency that cannot be resolved otherwise
@@ -196,6 +197,14 @@ export const moveTreeLineToDrawBuffer = (treeId: string) => {
     })
 }
 
+/**
+ * Update the edit settings of an individual tree line.
+ * This does also update the last edit settings as this was an edit incident.
+ * Alternatively, the updateAllLinesAges can be used, which is applied to all tree lines
+ * and bypasses the lastEditSettings, as this is an simulation incident.
+ * @param treeId - The ID of the tree line to be updated.
+ * @param settings - The settings to be updated.
+ */
 export const updateEditSettings = (treeId: string, settings: Partial<TreeEditSettings>) => {
     // find the correct treeLine
     
@@ -224,6 +233,25 @@ export const updateEditSettings = (treeId: string, settings: Partial<TreeEditSet
         ...lastEditSettings.peek(),
         ...settings
     }
+}
+
+export const updateAllLineAges = (ageChange: number) => {
+    // new rawTreeLineFeatures
+    const newRawFeatures = rawTreeLineFeatures.peek().map(line => {
+        return {
+            ...line,
+            properties: {
+                ...line.properties,
+                editSettings: {
+                    ...line.properties.editSettings,
+                    age: line.properties.editSettings.age + ageChange
+                }
+            }
+        }
+    })
+
+    // update
+    rawTreeLineFeatures.value = newRawFeatures
 }
 
 /**

--- a/src/appState/treeLineSignals.ts
+++ b/src/appState/treeLineSignals.ts
@@ -58,7 +58,7 @@ export const treeLines = computed<TreeLine>(() => {
 
 
 // create the treeLocations as a computed signal
-const treeLocationFeatures = computed<TreeLocation["features"]>(() => {
+const allTreeLocationFeatures = computed<TreeLocation["features"]>(() => {
     // map all features in treeLineFeatures to an array of treeLocations
     return rawTreeLineFeatures.value.flatMap(treeLine => {
         // get the current edit settings for this treeLine
@@ -93,6 +93,10 @@ const treeLocationFeatures = computed<TreeLocation["features"]>(() => {
     })
 })
 
+// sort into the treeLocationFeatures that currently exist and the ones that will be tere in the future
+const treeLocationFeatures = computed<TreeLocation["features"]>(() => allTreeLocationFeatures.value.filter(tree => tree.properties.age! > 0))
+const futureLocationFeatures = computed<TreeLocation["features"]>(() => allTreeLocationFeatures.value.filter(tree => tree.properties.age! <= 0))
+
 // export the treeLocations as a valid geoJSON
 export const treeLocations = computed<TreeLocation>(() => {
     // calculate the bounding box of all trees
@@ -102,6 +106,14 @@ export const treeLocations = computed<TreeLocation>(() => {
         type: "FeatureCollection",
         features: treeLocationFeatures.value,
         //bbox: treeBbox
+    }
+})
+
+// export the futureLocations as a valid geoJSON
+export const futureTreeLocations = computed<TreeLocation>(() => {
+    return {
+        type: "FeatureCollection",
+        features: futureLocationFeatures.value
     }
 })
 

--- a/src/components/Simulation/SimulationStepSlider.tsx
+++ b/src/components/Simulation/SimulationStepSlider.tsx
@@ -1,0 +1,26 @@
+import { Mark } from "@mui/base"
+import { Box, Slider, Typography } from "@mui/material"
+import { setSimulationStep, simulationStep } from "../../appState/simulationSignals"
+
+// hard-code some marks
+const marks: Mark[] = [
+    // {value: 5, label: '5'},
+    {value: 10, label: '10 Jahre'},
+    {value: 30, label: '30 Jahre'},
+    {value: 50, label: '50 Jahre'},
+    {value: 80, label: '80 Jahre'},
+]
+
+const SimulationStepSlider: React.FC = () => {
+    return <>
+        <Typography variant="h6">simuliere Baumwachstum</Typography>
+        <Box display="flex" mt={1}>
+            <Typography variant="body1" mr={2}>{simulationStep.value.current}</Typography>
+            <Slider marks={marks} valueLabelDisplay="auto" value={simulationStep.value.current} onChange={(e, value) => setSimulationStep(value as number)}/>
+            <Typography variant="body1" ml={1}>Jahre</Typography>
+        </Box>
+        
+    </>
+}
+
+export default SimulationStepSlider

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Box, Drawer, IconButton, MenuItem, MenuList, Toolbar, Typography } from "@mui/material"
+import { AppBar, Box, Card, CardContent, Drawer, IconButton, MenuItem, MenuList, Toolbar, Typography } from "@mui/material"
 import { DarkMode, LightMode, Menu, ArrowBack } from "@mui/icons-material"
 import { Outlet } from "react-router-dom"
 
@@ -6,7 +6,7 @@ import { useIntegraTheme, useModeToggler } from "../context/IntegraThemeContext"
 import MainMap from "../components/MainMap/MainMap"
 import DrawControl from "../components/MainMap/DrawControl"
 import TreeLineSource from "../components/MainMap/TreeLineSource"
-import { drawState } from "../appState/treeLineSignals"
+import { drawState, hasData } from "../appState/treeLineSignals"
 import { DrawState } from "../appState/treeLine.model"
 import DesktopContentCard from "../layout/desktop/DesktopContentCard"
 import TreeLineNewCard from "../layout/desktop/TreeLineNewCard"
@@ -15,6 +15,7 @@ import ReferenceAreaSource from "../components/MainMap/ReferenceAreaSource"
 import ProjectSelect from "../components/ProjectSelect"
 import { useSignal } from "@preact/signals-react"
 import MapLayerSwitchButton from "../components/MainMap/MapLayerSwitchButton"
+import SimulationStepSlider from "../components/Simulation/SimulationStepSlider"
 
 
 
@@ -84,6 +85,17 @@ const DesktopMain: React.FC = () => {
                 </DesktopContentCard>
             ) : <Outlet /> }
 
+            {/* Only render the simulation cards if there is data and no editing */}
+            { hasData.value && drawState.value === DrawState.OFF ? (<>
+                {/* add the simulation slider */}
+                <Box minWidth="250px" width="40vw" maxWidth="450px" position="fixed" bottom="25px" left="0" right="0" mx="auto" zIndex="99">
+                    <Card>
+                        <CardContent>
+                            <SimulationStepSlider />
+                        </CardContent>
+                    </Card>
+                </Box>
+            </>) : null }
 
             <MainMap mapId="desktop">
                 <DrawControl />


### PR DESCRIPTION
This basically closes #25 as specified.

You can run a simulation and the tooltip updates accordingly. This was all waaaaay easier thanks to signals. Therefore I would push some more commits here to implement something that visually updates as the simulation progresses. That is currently not the case.