### PR TITLE
Add statistics and make them explorable

### DIFF
--- a/public/model_data.csv
+++ b/public/model_data.csv
@@ -1,6 +1,6 @@
 Baumart;LateinischerName;Kürzel;Alter;Baumhöhe;BHD;Kronenbreite;Kronenansatzhöhe;AGB;Kohlenstoffgehalt
-Bergahorn;Acer pseudoplatanus L.;Ac ps;1;0.06;0.6;1.16;0.48;0.02;0.01
-Bergahorn;Acer pseudoplatanus L.;Ac ps;2;0.28;1.65;1.98;0.5;0.22;0.11
+Bergahorn;Acer pseudoplatanus L.;Ac ps;1;0.06;0.6;1.16;0.03;0.02;0.01
+Bergahorn;Acer pseudoplatanus L.;Ac ps;2;0.28;1.65;1.98;0.16;0.22;0.11
 Bergahorn;Acer pseudoplatanus L.;Ac ps;3;0.89;2.69;2.56;0.53;0.76;0.37
 Bergahorn;Acer pseudoplatanus L.;Ac ps;4;1.48;3.72;3.04;0.55;1.73;0.85
 Bergahorn;Acer pseudoplatanus L.;Ac ps;5;2.06;4.74;3.46;0.58;3.18;1.56
@@ -28,8 +28,8 @@ Bergahorn;Acer pseudoplatanus L.;Ac ps;90;22.05;56.9;12.86;1.84;1667.4;816.19
 Bergahorn;Acer pseudoplatanus L.;Ac ps;95;22.37;58.1;13;1.87;1757.4;860.25
 Bergahorn;Acer pseudoplatanus L.;Ac ps;100;22.68;59.1;13.12;1.89;1834.59;898.03
 Schwarzerle;Alnus glutinosa (L.) Gaertn.;Al gl;1;0.13;2.4;1.5;0.09;1.13;0.59
-Schwarzerle;Alnus glutinosa (L.) Gaertn.;Al gl;2;0.32;2.91;1.7;0.48;1.76;0.91
-Schwarzerle;Alnus glutinosa (L.) Gaertn.;Al gl;3;0.92;3.42;1.89;0.72;2.54;1.32
+Schwarzerle;Alnus glutinosa (L.) Gaertn.;Al gl;2;0.32;2.91;1.7;0.16;1.76;0.91
+Schwarzerle;Alnus glutinosa (L.) Gaertn.;Al gl;3;0.92;3.42;1.89;0.5;2.54;1.32
 Schwarzerle;Alnus glutinosa (L.) Gaertn.;Al gl;4;1.5;3.93;2.07;0.88;3.48;1.81
 Schwarzerle;Alnus glutinosa (L.) Gaertn.;Al gl;5;2.06;4.44;2.24;1.01;4.59;2.39
 Schwarzerle;Alnus glutinosa (L.) Gaertn.;Al gl;6;2.61;4.94;2.4;1.11;5.87;3.05
@@ -252,10 +252,10 @@ Linde;Tilia spp.;Ti spp.;85;15;39.72;9.25;2.02;576.73;286.35
 Linde;Tilia spp.;Ti spp.;90;15.46;41.87;9.4;2.04;656.17;325.79
 Linde;Tilia spp.;Ti spp.;95;15.9;43.99;9.54;2.06;740.72;367.77
 Linde;Tilia spp.;Ti spp.;100;16.32;46.08;9.67;2.08;830.29;412.24
-Gemeine Esche;Fraxinus excelsior;Fr ex;1;0;0.31;0.56;1.08;0;0
-Gemeine Esche;Fraxinus excelsior;Fr ex;2;0.07;0.94;1.1;1.09;0.07;0.04
-Gemeine Esche;Fraxinus excelsior;Fr ex;3;0.65;1.56;1.51;1.11;0.26;0.13
-Gemeine Esche;Fraxinus excelsior;Fr ex;4;1.21;2.18;1.86;1.12;0.59;0.29
+Gemeine Esche;Fraxinus excelsior;Fr ex;1;0.02;0.31;0.56;0.01;0;0
+Gemeine Esche;Fraxinus excelsior;Fr ex;2;0.07;0.94;1.1;0.035;0.07;0.04
+Gemeine Esche;Fraxinus excelsior;Fr ex;3;0.65;1.56;1.51;0.32;0.26;0.13
+Gemeine Esche;Fraxinus excelsior;Fr ex;4;1.21;2.18;1.86;0.65;0.59;0.29
 Gemeine Esche;Fraxinus excelsior;Fr ex;5;1.77;2.8;2.17;1.14;1.1;0.54
 Gemeine Esche;Fraxinus excelsior;Fr ex;6;2.32;3.41;2.45;1.15;1.81;0.88
 Gemeine Esche;Fraxinus excelsior;Fr ex;7;2.85;4.02;2.71;1.17;2.73;1.33

--- a/src/appState/simulationSignals.ts
+++ b/src/appState/simulationSignals.ts
@@ -1,0 +1,23 @@
+/**
+ * Simulations are used to change the state of the treeLine in place.
+ * 
+ * A simulation is controlled by a step since the start of the simulation
+ * and is measured in years.
+ */
+
+import { computed, signal } from "@preact/signals-react";
+
+// the iteration is too important, so we make it private to this module
+const step = signal<number>(0);
+
+// public read-only access to the duration - we could use a better name here
+export const simulationStep = computed<number>(() => step.value)
+
+// public handler to set the simulation duration directly
+export const setSimulationStep = (newStep: number) => {
+    // TODO: I implement some hard-coded rules here
+    // it is an INTEGER between 0 100
+    const validatedStep = Math.max(0, Math.min(Math.round(Number(newStep)), 100))
+
+    step.value = validatedStep
+}

--- a/src/appState/simulationSignals.ts
+++ b/src/appState/simulationSignals.ts
@@ -27,6 +27,17 @@ export const simulationStep = computed<SimulationStep>(() => {
 })
 
 // public handler to set the simulation duration directly
+/**
+ * Sets the current step of the simulation.
+ *
+ * @param newStep - The new step of the simulation.
+ *
+ * This function performs the following steps:
+ * 1. Validates the new step to ensure it is an integer between 0 and 100. If the new step is not within this range, it is clamped to the nearest valid value.
+ * 2. Retrieves the current step of the simulation.
+ * 3. If the validated new step is the same as the current step, the function returns immediately.
+ * 4. In a batch operation, it updates the current step to the validated new step and sets the previous step to the current step.
+ */
 export const setSimulationStep = (newStep: number) => {
     // TODO: I implement some hard-coded rules here
     // it is an INTEGER between 0 100
@@ -48,5 +59,5 @@ effect(() => {
     const ageChange = simulationStep.value.current - simulationStep.value.previous
 
     // update all treeLines accordingly
-    const newTreeLines = updateAllLineAges(ageChange)
+    updateAllLineAges(ageChange)
 })

--- a/src/appState/simulationSignals.ts
+++ b/src/appState/simulationSignals.ts
@@ -5,19 +5,48 @@
  * and is measured in years.
  */
 
-import { computed, signal } from "@preact/signals-react";
+import { batch, computed, effect, signal } from "@preact/signals-react";
+import { updateAllLineAges } from "./treeLineSignals";
 
 // the iteration is too important, so we make it private to this module
-const step = signal<number>(0);
+const step = signal<number>(0)
+const previousStep = signal<number>(-1)
+
 
 // public read-only access to the duration - we could use a better name here
-export const simulationStep = computed<number>(() => step.value)
+interface SimulationStep {
+    current: number,
+    previous: number
+}
+// the simulation step updates only if step changes, as it is updated in a batch with previousStep
+export const simulationStep = computed<SimulationStep>(() => {
+    return {
+        current: step.value,
+        previous: previousStep.peek()
+    }
+})
 
 // public handler to set the simulation duration directly
 export const setSimulationStep = (newStep: number) => {
     // TODO: I implement some hard-coded rules here
     // it is an INTEGER between 0 100
     const validatedStep = Math.max(0, Math.min(Math.round(Number(newStep)), 100))
-
-    step.value = validatedStep
+    const previous = step.peek()
+    
+    // only update if the step has changed
+    if (validatedStep === previous) return
+    
+    batch(() => {
+        step.value = validatedStep
+        previousStep.value = previous
+    })
 }
+
+// this is one of the tests right now: try to only update the treeLine as an effect of a changing step
+effect(() => {
+    // check if we need to decrease or increase the treeAge
+    const ageChange = simulationStep.value.current - simulationStep.value.previous
+
+    // update all treeLines accordingly
+    const newTreeLines = updateAllLineAges(ageChange)
+})

--- a/src/appState/statisticsSignals.ts
+++ b/src/appState/statisticsSignals.ts
@@ -30,14 +30,18 @@ export const referenceFeature = computed<GeoJSON.Feature<GeoJSON.Polygon> | null
 
 export const referenceArea = computed(() => referenceFeature.value ? area(referenceFeature.value) : 0)
 
-interface TreeTypeStatistics {
-    [treeType: string]: {
-        count: number,
-        countPerHectare: number,
-        totalCarbon?: number,
-        carbonPerHectare?: number,
-    }
+interface StatisticsDatapoint {
+    count: number,
+    countPerHectare: number,
+    totalCarbon?: number,
+    carbonPerHectare?: number,
 }
+
+export interface TreeTypeStatistics {
+    [treeType: string]: StatisticsDatapoint
+}
+
+export type StatMetric = "count" | "carbon"
 
 export const treeTypeStatistics = computed<TreeTypeStatistics>(() => {
     // calculate the current area
@@ -64,4 +68,15 @@ export const treeTypeStatistics = computed<TreeTypeStatistics>(() => {
     })
     
     return stats
+})
+
+export const totalStatistics = computed<StatisticsDatapoint>(() => {
+    // sum up all treeType statistics
+    // TODO: this can be done in a loop so far
+    return {
+        count: Object.values(treeTypeStatistics.value).map(t => t.count).reduce((t1, t2) => t1 + t2, 0),
+        countPerHectare: Object.values(treeTypeStatistics.value).map(t => t.countPerHectare).reduce((t1, t2) => t1 + t2, 0),
+        totalCarbon: Object.values(treeTypeStatistics.value).map(t => t.totalCarbon || 0).reduce((t1, t2) => t1 + t2, 0),
+        carbonPerHectare: Object.values(treeTypeStatistics.value).map(t => t.carbonPerHectare || 0).reduce((t1, t2) => t1 + t2, 0),
+    }
 })

--- a/src/appState/statisticsSignals.ts
+++ b/src/appState/statisticsSignals.ts
@@ -34,6 +34,8 @@ interface TreeTypeStatistics {
     [treeType: string]: {
         count: number,
         countPerHectare: number,
+        totalCarbon?: number,
+        carbonPerHectare?: number,
     }
 }
 
@@ -47,11 +49,17 @@ export const treeTypeStatistics = computed<TreeTypeStatistics>(() => {
     // calculate all the statistics by tree type
     const stats = {} as TreeTypeStatistics
     treeTypes.forEach(treeType => {
-        // count statistics
-        const count = treeLocations.value.features.filter(tree => tree.properties.treeType === treeType).length
+        // filter the tree locations by tree type
+        const individuals = treeLocations.value.features.filter(tree => tree.properties.treeType === treeType)
+
+        // carbon statistics
+        const totalCarbon = individuals.map(tree => tree.properties.carbon || 0).reduce((t1, t2) => t1 + t2, 0)
+ 
         stats[treeType] = {
-            count: count,
-            countPerHectare: count / (referenceArea.value / 10000),
+            count: individuals.length,
+            countPerHectare: individuals.length / (referenceArea.value / 10000),
+            totalCarbon: totalCarbon,
+            carbonPerHectare: totalCarbon / (referenceArea.value / 10000),
         }
     })
     

--- a/src/appState/statisticsSignals.ts
+++ b/src/appState/statisticsSignals.ts
@@ -37,6 +37,9 @@ interface StatisticsDatapoint {
     carbonPerHectare?: number,
     totalAgb?: number,
     agbPerHectare?: number,
+    meanHeight?: number,
+    meanTruncHeight?: number,
+    meanBhd?: number,
 }
 
 export interface TreeTypeStatistics {
@@ -61,7 +64,14 @@ export const treeTypeStatistics = computed<TreeTypeStatistics>(() => {
         // carbon statistics
         const totalCarbon = individuals.map(tree => tree.properties.carbon || 0).reduce((t1, t2) => t1 + t2, 0)
         const totalAgb = individuals.map(tree => tree.properties.agb || 0).reduce((t1, t2) => t1 + t2, 0)
- 
+
+        // height statistics
+        const meanHeight = individuals.map(tree => tree.properties.height || 0).reduce((t1, t2) => t1 + t2, 0) / individuals.length
+        const meanTruncHeight = individuals.map(tree => (tree.properties.height || 0) - (tree.properties.canopyHeight || 0)).reduce((t1, t2) => t1 + t2, 0) / individuals.length
+        
+        // BHD statistics
+        const meanBhd = individuals.map(tree => tree.properties.bhd || 0).reduce((t1, t2) => t1 + t2, 0) / individuals.length
+
         stats[treeType] = {
             count: individuals.length,
             countPerHectare: individuals.length / (referenceArea.value / 10000),
@@ -69,6 +79,9 @@ export const treeTypeStatistics = computed<TreeTypeStatistics>(() => {
             carbonPerHectare: totalCarbon / (referenceArea.value / 10000),
             totalAgb: totalAgb,
             agbPerHectare: totalAgb / (referenceArea.value / 10000),
+            meanHeight: meanHeight,
+            meanTruncHeight: meanTruncHeight,
+            meanBhd: meanBhd,
         }
     })
     
@@ -85,5 +98,8 @@ export const totalStatistics = computed<StatisticsDatapoint>(() => {
         carbonPerHectare: Object.values(treeTypeStatistics.value).map(t => t.carbonPerHectare || 0).reduce((t1, t2) => t1 + t2, 0),
         totalAgb: Object.values(treeTypeStatistics.value).map(t => t.totalAgb || 0).reduce((t1, t2) => t1 + t2, 0),
         agbPerHectare: Object.values(treeTypeStatistics.value).map(t => t.agbPerHectare || 0).reduce((t1, t2) => t1 + t2, 0),
+        meanHeight: Object.values(treeTypeStatistics.value).map(t => t.meanHeight || 0).reduce((t1, t2) => t1 + t2, 0) / Object.keys(treeTypeStatistics.value).length,
+        meanTruncHeight: Object.values(treeTypeStatistics.value).map(t => t.meanTruncHeight || 0).reduce((t1, t2) => t1 + t2, 0) / Object.keys(treeTypeStatistics.value).length,
+        meanBhd: Object.values(treeTypeStatistics.value).map(t => t.meanBhd || 0).reduce((t1, t2) => t1 + t2, 0) / Object.keys(treeTypeStatistics.value).length,
     }
 })

--- a/src/appState/statisticsSignals.ts
+++ b/src/appState/statisticsSignals.ts
@@ -35,6 +35,8 @@ interface StatisticsDatapoint {
     countPerHectare: number,
     totalCarbon?: number,
     carbonPerHectare?: number,
+    totalAgb?: number,
+    agbPerHectare?: number,
 }
 
 export interface TreeTypeStatistics {
@@ -58,12 +60,15 @@ export const treeTypeStatistics = computed<TreeTypeStatistics>(() => {
 
         // carbon statistics
         const totalCarbon = individuals.map(tree => tree.properties.carbon || 0).reduce((t1, t2) => t1 + t2, 0)
+        const totalAgb = individuals.map(tree => tree.properties.agb || 0).reduce((t1, t2) => t1 + t2, 0)
  
         stats[treeType] = {
             count: individuals.length,
             countPerHectare: individuals.length / (referenceArea.value / 10000),
             totalCarbon: totalCarbon,
             carbonPerHectare: totalCarbon / (referenceArea.value / 10000),
+            totalAgb: totalAgb,
+            agbPerHectare: totalAgb / (referenceArea.value / 10000),
         }
     })
     
@@ -78,5 +83,7 @@ export const totalStatistics = computed<StatisticsDatapoint>(() => {
         countPerHectare: Object.values(treeTypeStatistics.value).map(t => t.countPerHectare).reduce((t1, t2) => t1 + t2, 0),
         totalCarbon: Object.values(treeTypeStatistics.value).map(t => t.totalCarbon || 0).reduce((t1, t2) => t1 + t2, 0),
         carbonPerHectare: Object.values(treeTypeStatistics.value).map(t => t.carbonPerHectare || 0).reduce((t1, t2) => t1 + t2, 0),
+        totalAgb: Object.values(treeTypeStatistics.value).map(t => t.totalAgb || 0).reduce((t1, t2) => t1 + t2, 0),
+        agbPerHectare: Object.values(treeTypeStatistics.value).map(t => t.agbPerHectare || 0).reduce((t1, t2) => t1 + t2, 0),
     }
 })

--- a/src/appState/statisticsSignals.ts
+++ b/src/appState/statisticsSignals.ts
@@ -46,7 +46,7 @@ export interface TreeTypeStatistics {
     [treeType: string]: StatisticsDatapoint
 }
 
-export type StatMetric = "count" | "carbon"
+export type StatMetric = "count" | "carbon" | "agb" | "height"
 
 export const treeTypeStatistics = computed<TreeTypeStatistics>(() => {
     // calculate the current area

--- a/src/appState/treeLineSignals.ts
+++ b/src/appState/treeLineSignals.ts
@@ -235,6 +235,17 @@ export const updateEditSettings = (treeId: string, settings: Partial<TreeEditSet
     }
 }
 
+/**
+ * Updates the age of all tree lines by a specified amount.
+ *
+ * @param ageChange - The change in age to be applied to all tree lines.
+ *
+ * This function performs the following steps:
+ * 1. Retrieves the current state of the rawTreeLineFeatures.
+ * 2. Maps over each tree line in the rawTreeLineFeatures.
+ * 3. For each tree line, it creates a new object that is a copy of the original tree line, but with the `age` property of the `editSettings` updated by the specified `ageChange`.
+ * 4. The result is a new array of tree lines with updated ages, which is then used to update the state of the rawTreeLineFeatures.
+ */
 export const updateAllLineAges = (ageChange: number) => {
     // new rawTreeLineFeatures
     const newRawFeatures = rawTreeLineFeatures.peek().map(line => {

--- a/src/appState/treeLineSignals.ts
+++ b/src/appState/treeLineSignals.ts
@@ -27,6 +27,7 @@ export const drawState = signal<DrawState>(DrawState.OFF)
 // main signal to hold the treeLine data
 const rawTreeLineFeatures = signal<TreeLine["features"]>([])
 export const readOnlyRawTreeLineFeatures = computed(() => rawTreeLineFeatures.value)
+export const hasData = computed<boolean>(() => rawTreeLineFeatures.value.length > 0)
 
 // we need the treeLineFeatues twice, as some of the attributes depend on the treeLocation
 // which is a circular dependency that cannot be resolved otherwise
@@ -196,6 +197,14 @@ export const moveTreeLineToDrawBuffer = (treeId: string) => {
     })
 }
 
+/**
+ * Update the edit settings of an individual tree line.
+ * This does also update the last edit settings as this was an edit incident.
+ * Alternatively, the updateAllLinesAges can be used, which is applied to all tree lines
+ * and bypasses the lastEditSettings, as this is an simulation incident.
+ * @param treeId - The ID of the tree line to be updated.
+ * @param settings - The settings to be updated.
+ */
 export const updateEditSettings = (treeId: string, settings: Partial<TreeEditSettings>) => {
     // find the correct treeLine
     
@@ -224,6 +233,25 @@ export const updateEditSettings = (treeId: string, settings: Partial<TreeEditSet
         ...lastEditSettings.peek(),
         ...settings
     }
+}
+
+export const updateAllLineAges = (ageChange: number) => {
+    // new rawTreeLineFeatures
+    const newRawFeatures = rawTreeLineFeatures.peek().map(line => {
+        return {
+            ...line,
+            properties: {
+                ...line.properties,
+                editSettings: {
+                    ...line.properties.editSettings,
+                    age: line.properties.editSettings.age + ageChange
+                }
+            }
+        }
+    })
+
+    // update
+    rawTreeLineFeatures.value = newRawFeatures
 }
 
 /**

--- a/src/appState/treeLineSignals.ts
+++ b/src/appState/treeLineSignals.ts
@@ -75,8 +75,12 @@ const allTreeLocationFeatures = computed<TreeLocation["features"]>(() => {
         // build the new locations
         const trees: TreeLocation["features"] = []
         for (let i = 0; i <= numTrees; i++) {
+            // calculate a new point
             const newPoint = along(treeLine, (i * settings.spacing) + offset, {units: "meters"})
 
+            // load the closes TreeDataPoint. We need to spread this into a new object to not overwrite the
+            // actual tree age by the 'age' marking the TreeDataPoint
+            const {age, ...data} = loadClosestDataPoint(settings.treeType, settings.age)
             // add to the new tree locations
             trees.push({
                 ...newPoint,
@@ -85,8 +89,9 @@ const allTreeLocationFeatures = computed<TreeLocation["features"]>(() => {
                     treeLineId: treeLine.properties.id,
                     treeType: settings.treeType,
 
-                    // load the closest TreeDataPoint according to the type and age that the line currently holds
-                    ...loadClosestDataPoint(settings.treeType, settings.age)
+                    // spread everything here, but use the age from the !settings!
+                    ...data,
+                    age: settings.age
                 }
             })
         }

--- a/src/appState/treeLineSignals.ts
+++ b/src/appState/treeLineSignals.ts
@@ -58,7 +58,7 @@ export const treeLines = computed<TreeLine>(() => {
 
 
 // create the treeLocations as a computed signal
-const treeLocationFeatures = computed<TreeLocation["features"]>(() => {
+const allTreeLocationFeatures = computed<TreeLocation["features"]>(() => {
     // map all features in treeLineFeatures to an array of treeLocations
     return rawTreeLineFeatures.value.flatMap(treeLine => {
         // get the current edit settings for this treeLine
@@ -93,6 +93,10 @@ const treeLocationFeatures = computed<TreeLocation["features"]>(() => {
     })
 })
 
+// sort into the treeLocationFeatures that currently exist and the ones that will be tere in the future
+const treeLocationFeatures = computed<TreeLocation["features"]>(() => allTreeLocationFeatures.value.filter(tree => tree.properties.age! > 0))
+const futureLocationFeatures = computed<TreeLocation["features"]>(() => allTreeLocationFeatures.value.filter(tree => tree.properties.age! <= 0))
+
 // export the treeLocations as a valid geoJSON
 export const treeLocations = computed<TreeLocation>(() => {
     // calculate the bounding box of all trees
@@ -102,6 +106,14 @@ export const treeLocations = computed<TreeLocation>(() => {
         type: "FeatureCollection",
         features: treeLocationFeatures.value,
         //bbox: treeBbox
+    }
+})
+
+// export the futureLocations as a valid geoJSON
+export const futureTreeLocations = computed<TreeLocation>(() => {
+    return {
+        type: "FeatureCollection",
+        features: futureLocationFeatures.value
     }
 })
 

--- a/src/components/Simulation/AGBResultDetailContent.tsx
+++ b/src/components/Simulation/AGBResultDetailContent.tsx
@@ -1,0 +1,25 @@
+import { Box, Grid, Typography } from "@mui/material"
+import { totalStatistics } from "../../appState/statisticsSignals"
+import MetricSwitchHeader from "./MetricSwitchHeader"
+
+const AGBResultDetailContent: React.FC<{onSwitch: (metricName: string) => void}> = ({ onSwitch }) => {
+    return <>
+        <MetricSwitchHeader metricTitle="Oberirdische Biomasse" metric="agb" onSwitch={onSwitch} />
+        <Grid container spacing={0}>
+            <Grid item xs={6}>
+                <Typography variant="h2">{ ((totalStatistics.value.totalAgb || 0)  / 1000).toFixed(0) } t</Typography>
+                <Typography variant="body1">Absolut</Typography>
+            </Grid>
+            <Grid item xs={6}>
+                <Box display="flex" flexDirection="row" alignItems="baseline">
+                <Typography variant="h2">{ ((totalStatistics.value.totalAgb || 0) * 4 / 1000).toFixed(0) }</Typography>
+                <Typography variant="h6" ml={1}>MWh</Typography>
+                </Box>
+                <Typography variant="body1">Brennwert</Typography>
+                <Typography variant="caption">~ {((totalStatistics.value.totalAgb || 0) * 4 / 1000 / 2.5).toFixed(0)} m<sup>3</sup> Heizöl</Typography>
+            </Grid>
+        </Grid>
+    </>
+}
+
+export default AGBResultDetailContent

--- a/src/components/Simulation/CarbonResultDetailContent.tsx
+++ b/src/components/Simulation/CarbonResultDetailContent.tsx
@@ -1,0 +1,20 @@
+import { Grid, Typography } from "@mui/material"
+import { totalStatistics } from "../../appState/statisticsSignals"
+
+const CarbonResultDetailContent: React.FC = () => {
+    return <>
+        <Typography variant="h6">Kohlenstoffgehalt</Typography>
+        <Grid container spacing={0}>
+            <Grid item xs={6}>
+                <Typography variant="h2">{ ((totalStatistics.value.totalCarbon || 0)  / 1000).toFixed(0) } t</Typography>
+                <Typography variant="body1">Absolut</Typography>
+            </Grid>
+            <Grid item xs={6}>
+                <Typography variant="h2">{ ((totalStatistics.value.totalCarbon || 0)  / 1000 * 3.667).toFixed(0) } t</Typography>
+                <Typography variant="body1">CO<sub>2</sub> Einsparung</Typography>
+            </Grid>
+        </Grid>
+    </>
+}
+
+export default CarbonResultDetailContent

--- a/src/components/Simulation/CarbonResultDetailContent.tsx
+++ b/src/components/Simulation/CarbonResultDetailContent.tsx
@@ -1,9 +1,10 @@
 import { Grid, Typography } from "@mui/material"
 import { totalStatistics } from "../../appState/statisticsSignals"
+import MetricSwitchHeader from "./MetricSwitchHeader"
 
-const CarbonResultDetailContent: React.FC = () => {
+const CarbonResultDetailContent: React.FC<{onSwitch: (metricName: string) => void}> = ({ onSwitch }) => {
     return <>
-        <Typography variant="h6">Kohlenstoffgehalt</Typography>
+        <MetricSwitchHeader metricTitle="Kohlenstoffgehalt" metric="carbon" onSwitch={onSwitch} />
         <Grid container spacing={0}>
             <Grid item xs={6}>
                 <Typography variant="h2">{ ((totalStatistics.value.totalCarbon || 0)  / 1000).toFixed(0) } t</Typography>

--- a/src/components/Simulation/CountResultDetailContent.tsx
+++ b/src/components/Simulation/CountResultDetailContent.tsx
@@ -1,0 +1,21 @@
+import { Grid, Typography } from "@mui/material"
+import { totalStatistics } from "../../appState/statisticsSignals"
+import MetricSwitchHeader from "./MetricSwitchHeader"
+
+const CountResultDetailContent: React.FC<{onSwitch: (metricName: string) => void}> = ({ onSwitch }) => {
+    return <>
+        <MetricSwitchHeader metricTitle="Baumanzahl" metric="count" onSwitch={onSwitch} />
+        <Grid container spacing={0}>
+            <Grid item xs={6}>
+                <Typography variant="h2">{ (totalStatistics.value.count || 0).toFixed(0) }</Typography>
+                <Typography variant="body1">Bäume gesamt</Typography>
+            </Grid>
+            <Grid item xs={6}>
+                <Typography variant="h2">{ (totalStatistics.value.countPerHectare || 0).toFixed(0) }</Typography>
+                <Typography variant="body1">Bäume pro Hektar</Typography>
+            </Grid>
+        </Grid>
+    </>
+}
+
+export default CountResultDetailContent

--- a/src/components/Simulation/HeightResultDetailContent.tsx
+++ b/src/components/Simulation/HeightResultDetailContent.tsx
@@ -1,0 +1,28 @@
+import { Box, Grid, Typography } from "@mui/material"
+import MetricSwitchHeader from "./MetricSwitchHeader"
+import { totalStatistics } from "../../appState/statisticsSignals"
+
+const HeightResultDetailContent: React.FC<{onSwitch: (metricName: string) => void}> = ({ onSwitch }) => {
+    return <>
+        <MetricSwitchHeader metricTitle="Baumhöhen" metric="height" onSwitch={onSwitch} />
+        <Grid container spacing={0}>
+            <Grid item xs={6}>
+                <Box display="flex" flexDirection="row" alignItems="baseline">
+                    <Typography variant="h2">{ (totalStatistics.value.meanHeight || 0).toFixed(1) }</Typography>
+                    <Typography variant="h6" ml={1}>m</Typography>
+                </Box>
+                <Typography variant="body1">mittlere Baumhöhe</Typography>
+            </Grid>
+            <Grid item xs={6}>
+                <Box display="flex" flexDirection="row" alignItems="baseline">
+                    <Typography variant="h2">{ (totalStatistics.value.meanTruncHeight || 0).toFixed(1) }</Typography>
+                    <Typography variant="h6" ml={1}>m</Typography>
+                </Box>
+                <Typography variant="body1">mittlere Stammlänge</Typography>
+            </Grid>
+
+        </Grid>
+    </>
+}
+
+export default HeightResultDetailContent

--- a/src/components/Simulation/HeightResultDetailContent.tsx
+++ b/src/components/Simulation/HeightResultDetailContent.tsx
@@ -4,21 +4,21 @@ import { totalStatistics } from "../../appState/statisticsSignals"
 
 const HeightResultDetailContent: React.FC<{onSwitch: (metricName: string) => void}> = ({ onSwitch }) => {
     return <>
-        <MetricSwitchHeader metricTitle="Baumhöhen" metric="height" onSwitch={onSwitch} />
+        <MetricSwitchHeader metricTitle="mittlere Baumhöhen" metric="height" onSwitch={onSwitch} />
         <Grid container spacing={0}>
             <Grid item xs={6}>
                 <Box display="flex" flexDirection="row" alignItems="baseline">
                     <Typography variant="h2">{ (totalStatistics.value.meanHeight || 0).toFixed(1) }</Typography>
                     <Typography variant="h6" ml={1}>m</Typography>
                 </Box>
-                <Typography variant="body1">mittlere Baumhöhe</Typography>
+                <Typography variant="body1">Baumhöhe</Typography>
             </Grid>
             <Grid item xs={6}>
                 <Box display="flex" flexDirection="row" alignItems="baseline">
                     <Typography variant="h2">{ (totalStatistics.value.meanTruncHeight || 0).toFixed(1) }</Typography>
                     <Typography variant="h6" ml={1}>m</Typography>
                 </Box>
-                <Typography variant="body1">mittlere Stammlänge</Typography>
+                <Typography variant="body1">Stammlänge</Typography>
             </Grid>
 
         </Grid>

--- a/src/components/Simulation/MetricSwitchHeader.tsx
+++ b/src/components/Simulation/MetricSwitchHeader.tsx
@@ -1,30 +1,33 @@
 import { FormControl, MenuItem, Select, Typography } from "@mui/material"
 import { useSignal } from "@preact/signals-react"
 import { NAME_LOOKUP } from "./SimulationResultDetailCard"
+import { useState } from "react"
 
 
 const MetricSwitchHeader: React.FC<{metric: string, metricTitle: string, onSwitch: (metricName: string) => void}> = ({ metric, metricTitle, onSwitch }) => {
     // state to check that we need to switch to a select
     const isSelect = useSignal<boolean>(false)
+    //const [isSelect, setIsSelect] = useState<boolean>(false)
 
     const onSelectionChanged = (metricName: string) => {
-        // set back to typography
-        isSelect.value = false
-
         // call the callback
         onSwitch(metricName)
     }
 
+    const enableSelect = () => {
+        isSelect.value = true
+    }
+
     return <>
-        {isSelect.value ? (
-            <FormControl variant="standard">
+        {/* {isSelect.value ? ( */}
+            <FormControl variant="standard" sx={{display: isSelect.value ? 'block' : 'none'}}>
             <Select value="current" onChange={e => onSelectionChanged(e.target.value)}>
                 {/* add the other options */}
                 { Object.entries(NAME_LOOKUP).map(([name, m]) => {
                     if (name === metric) {
-                        return <MenuItem value="current" disabled>{metricTitle}</MenuItem>
+                        return <MenuItem key="current" value="current" disabled>{metricTitle}</MenuItem>
                     } else {
-                        return <MenuItem value={name}>{m.title}</MenuItem>
+                        return <MenuItem key={name} value={name}>{m.title}</MenuItem>
                     }
                     
                 }) }
@@ -33,9 +36,9 @@ const MetricSwitchHeader: React.FC<{metric: string, metricTitle: string, onSwitc
                 
             </Select>
             </FormControl>
-        ) : (
-            <Typography variant="h6" sx={{cursor: 'pointer'}} onClick={() => isSelect.value = true}>{metricTitle}</Typography>
-        ) }
+        {/* ) : ( */}
+            <Typography variant="h6" sx={{cursor: 'pointer', display: isSelect.value ? 'none' : 'block'}} onClick={enableSelect}>{metricTitle}</Typography>
+        {/* ) } */}
     </>
 }
 

--- a/src/components/Simulation/MetricSwitchHeader.tsx
+++ b/src/components/Simulation/MetricSwitchHeader.tsx
@@ -1,0 +1,42 @@
+import { FormControl, MenuItem, Select, Typography } from "@mui/material"
+import { useSignal } from "@preact/signals-react"
+import { NAME_LOOKUP } from "./SimulationResultDetailCard"
+
+
+const MetricSwitchHeader: React.FC<{metric: string, metricTitle: string, onSwitch: (metricName: string) => void}> = ({ metric, metricTitle, onSwitch }) => {
+    // state to check that we need to switch to a select
+    const isSelect = useSignal<boolean>(false)
+
+    const onSelectionChanged = (metricName: string) => {
+        // set back to typography
+        isSelect.value = false
+
+        // call the callback
+        onSwitch(metricName)
+    }
+
+    return <>
+        {isSelect.value ? (
+            <FormControl variant="standard">
+            <Select value="current" onChange={e => onSelectionChanged(e.target.value)}>
+                {/* add the other options */}
+                { Object.entries(NAME_LOOKUP).map(([name, m]) => {
+                    if (name === metric) {
+                        return <MenuItem value="current" disabled>{metricTitle}</MenuItem>
+                    } else {
+                        return <MenuItem value={name}>{m.title}</MenuItem>
+                    }
+                    
+                }) }
+
+                {/* also add the current one, but disabled */}
+                
+            </Select>
+            </FormControl>
+        ) : (
+            <Typography variant="h6" sx={{cursor: 'pointer'}} onClick={() => isSelect.value = true}>{metricTitle}</Typography>
+        ) }
+    </>
+}
+
+export default MetricSwitchHeader

--- a/src/components/Simulation/SimulationResultDetailCard.tsx
+++ b/src/components/Simulation/SimulationResultDetailCard.tsx
@@ -1,0 +1,67 @@
+import { Box, CardActionArea, Collapse, IconButton, LinearProgress, Typography } from "@mui/material"
+import { ExpandLess, ExpandMore } from "@mui/icons-material"
+import { useSignal, useSignalEffect } from "@preact/signals-react"
+import { StatMetric, TreeTypeStatistics, totalStatistics } from "../../appState/statisticsSignals"
+import CarbonResultDetailContent from "./CarbonResultDetailContent"
+
+// global Names for the title
+export interface Metric {
+    name: string,
+    title: string,
+    totalIdentifier: keyof TreeTypeStatistics[0],
+    reference: number,
+    unit: string
+}
+
+const NAME_LOOKUP: {[key: string]: Metric} = {
+    count: {name: 'count', title: 'Baumanzahl', totalIdentifier: 'countPerHectare', reference: 100, unit: '100 Bäume / ha'},
+    carbon: {name: 'carbon', title: 'Kohlenstoffgehalt', totalIdentifier: 'carbonPerHectare', reference: 10000, unit: '10 t / ha'},
+}
+
+const SimulationResultDetailCard: React.FC<{defaultMetric: StatMetric}> = ({ defaultMetric }) => {
+    // state to toggle the card
+    const open = useSignal<boolean>(false)
+
+    // state to handle the metric
+    const metric = useSignal<Metric>(NAME_LOOKUP[defaultMetric])
+    const totalValue = useSignal<number>(0)
+
+    // calcualte the total value from the current metric
+    useSignalEffect(() => {
+        totalValue.value = totalStatistics.value[metric.value.totalIdentifier] || 0
+    })
+
+
+    return <>
+        {/* Header to make the Card lager or smaller */}
+        <CardActionArea onClick={() => open.value = !open.peek()}>
+            <Box display="flex" flexDirection="row" justifyContent="space-between">
+                <Box sx={{flexGrow: 1, px: 1}}>
+                    <Typography variant="body2">{ open.value ? <>&nbsp;</>  : metric.value.title }</Typography>
+                    <Box display="flex" flexDirection="row" alignItems="center">
+                        <Box flexGrow={1}>
+                            <LinearProgress 
+                                variant="determinate"
+                                value={Math.min((totalValue.value / metric.peek().reference) * 100, 100)}
+                                color={(totalValue.value / metric.peek().reference) * 100 > 50 ? 'success' : 'primary'}
+                            />
+                        </Box>
+                    <Typography variant="body2" ml={1}>{metric.peek().unit}</Typography>
+                    </Box>
+                </Box>
+                
+                <IconButton size="small" edge="end" disableRipple>
+                    {open.value ? <ExpandLess /> : <ExpandMore />}
+                </IconButton>
+            </Box>
+        </CardActionArea>
+        <Collapse in={open.value}>
+            <Box p={1}>
+                { metric.value.name === 'carbon' ? <CarbonResultDetailContent /> : null }
+                
+            </Box>
+        </Collapse>
+    </>
+}
+
+export default SimulationResultDetailCard

--- a/src/components/Simulation/SimulationResultDetailCard.tsx
+++ b/src/components/Simulation/SimulationResultDetailCard.tsx
@@ -4,6 +4,7 @@ import { useSignal, useSignalEffect } from "@preact/signals-react"
 import { StatMetric, TreeTypeStatistics, totalStatistics } from "../../appState/statisticsSignals"
 import CarbonResultDetailContent from "./CarbonResultDetailContent"
 import CountResultDetailContent from "./CountResultDetailContent"
+import AGBResultDetailContent from "./AGBResultDetailContent"
 
 // global Names for the title
 export interface Metric {
@@ -17,6 +18,7 @@ export interface Metric {
 export const NAME_LOOKUP: {[key: string]: Metric} = {
     count: {name: 'count', title: 'Baumanzahl', totalIdentifier: 'countPerHectare', reference: 100, unit: '100 Bäume / ha'},
     carbon: {name: 'carbon', title: 'Kohlenstoffgehalt', totalIdentifier: 'carbonPerHectare', reference: 10000, unit: '10 t / ha'},
+    agb: {name: 'agb', title: 'Oberirdische Biomasse', totalIdentifier: 'agbPerHectare', reference: 10000, unit: '10 t / ha'},
 }
 
 const SimulationResultDetailCard: React.FC<{defaultMetric: StatMetric}> = ({ defaultMetric }) => {
@@ -67,6 +69,7 @@ const SimulationResultDetailCard: React.FC<{defaultMetric: StatMetric}> = ({ def
             <Box p={1}>
                 { metric.value.name === 'carbon' ? <CarbonResultDetailContent onSwitch={changeMetric} /> : null }
                 { metric.value.name === 'count' ? <CountResultDetailContent onSwitch={changeMetric} /> : null }
+                { metric.value.name === 'agb' ? <AGBResultDetailContent onSwitch={changeMetric} /> : null }
                 
             </Box>
         </Collapse>

--- a/src/components/Simulation/SimulationResultDetailCard.tsx
+++ b/src/components/Simulation/SimulationResultDetailCard.tsx
@@ -5,6 +5,7 @@ import { StatMetric, TreeTypeStatistics, totalStatistics } from "../../appState/
 import CarbonResultDetailContent from "./CarbonResultDetailContent"
 import CountResultDetailContent from "./CountResultDetailContent"
 import AGBResultDetailContent from "./AGBResultDetailContent"
+import HeightResultDetailContent from "./HeightResultDetailContent"
 
 // global Names for the title
 export interface Metric {
@@ -19,6 +20,7 @@ export const NAME_LOOKUP: {[key: string]: Metric} = {
     count: {name: 'count', title: 'Baumanzahl', totalIdentifier: 'countPerHectare', reference: 100, unit: '100 Bäume / ha'},
     carbon: {name: 'carbon', title: 'Kohlenstoffgehalt', totalIdentifier: 'carbonPerHectare', reference: 10000, unit: '10 t / ha'},
     agb: {name: 'agb', title: 'Oberirdische Biomasse', totalIdentifier: 'agbPerHectare', reference: 10000, unit: '10 t / ha'},
+    height: {name: 'height', title: 'Baumhöhen', totalIdentifier: 'meanHeight', reference: 20, unit: '20 m'}
 }
 
 const SimulationResultDetailCard: React.FC<{defaultMetric: StatMetric}> = ({ defaultMetric }) => {
@@ -70,7 +72,7 @@ const SimulationResultDetailCard: React.FC<{defaultMetric: StatMetric}> = ({ def
                 { metric.value.name === 'carbon' ? <CarbonResultDetailContent onSwitch={changeMetric} /> : null }
                 { metric.value.name === 'count' ? <CountResultDetailContent onSwitch={changeMetric} /> : null }
                 { metric.value.name === 'agb' ? <AGBResultDetailContent onSwitch={changeMetric} /> : null }
-                
+                { metric.value.name === 'height' ? <HeightResultDetailContent onSwitch={changeMetric} /> : null }
             </Box>
         </Collapse>
     </>

--- a/src/components/Simulation/SimulationResultDetailCard.tsx
+++ b/src/components/Simulation/SimulationResultDetailCard.tsx
@@ -3,6 +3,7 @@ import { ExpandLess, ExpandMore } from "@mui/icons-material"
 import { useSignal, useSignalEffect } from "@preact/signals-react"
 import { StatMetric, TreeTypeStatistics, totalStatistics } from "../../appState/statisticsSignals"
 import CarbonResultDetailContent from "./CarbonResultDetailContent"
+import CountResultDetailContent from "./CountResultDetailContent"
 
 // global Names for the title
 export interface Metric {
@@ -13,7 +14,7 @@ export interface Metric {
     unit: string
 }
 
-const NAME_LOOKUP: {[key: string]: Metric} = {
+export const NAME_LOOKUP: {[key: string]: Metric} = {
     count: {name: 'count', title: 'Baumanzahl', totalIdentifier: 'countPerHectare', reference: 100, unit: '100 Bäume / ha'},
     carbon: {name: 'carbon', title: 'Kohlenstoffgehalt', totalIdentifier: 'carbonPerHectare', reference: 10000, unit: '10 t / ha'},
 }
@@ -23,7 +24,7 @@ const SimulationResultDetailCard: React.FC<{defaultMetric: StatMetric}> = ({ def
     const open = useSignal<boolean>(false)
 
     // state to handle the metric
-    const metric = useSignal<Metric>(NAME_LOOKUP[defaultMetric])
+    const metric = useSignal<Metric>({...NAME_LOOKUP[defaultMetric]})
     const totalValue = useSignal<number>(0)
 
     // calcualte the total value from the current metric
@@ -31,11 +32,20 @@ const SimulationResultDetailCard: React.FC<{defaultMetric: StatMetric}> = ({ def
         totalValue.value = totalStatistics.value[metric.value.totalIdentifier] || 0
     })
 
+    // pass a handler to child components, that can switch the metric
+    const changeMetric = (metricName: string) => {
+        if (Object.keys(NAME_LOOKUP).includes(metricName)) {
+            metric.value = {...NAME_LOOKUP[metricName]}
+        } else {
+            console.error(`Metric ${metricName} not found`)
+        }
+    }
+
 
     return <>
         {/* Header to make the Card lager or smaller */}
         <CardActionArea onClick={() => open.value = !open.peek()}>
-            <Box display="flex" flexDirection="row" justifyContent="space-between">
+            <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center" py={0.5}>
                 <Box display="flex" flexDirection="row" alignItems="center" flexGrow={1} pl={1}>
                 <Typography variant="body2" mr={1}>{ open.value ? <>&nbsp;</>  : metric.value.title }</Typography>
                     <Box flexGrow={1}>
@@ -48,14 +58,15 @@ const SimulationResultDetailCard: React.FC<{defaultMetric: StatMetric}> = ({ def
                 <Typography variant="body2" ml={1}>{metric.peek().unit}</Typography>
                 </Box>
                 
-                <IconButton size="small" edge="end" disableRipple>
-                    {open.value ? <ExpandLess /> : <ExpandMore />}
-                </IconButton>
+                {/* <IconButton size="small" edge="end" disableRipple> */}
+                {open.value ? <ExpandLess /> : <ExpandMore />}
+                {/* </IconButton> */}
             </Box>
         </CardActionArea>
         <Collapse in={open.value}>
             <Box p={1}>
-                { metric.value.name === 'carbon' ? <CarbonResultDetailContent /> : null }
+                { metric.value.name === 'carbon' ? <CarbonResultDetailContent onSwitch={changeMetric} /> : null }
+                { metric.value.name === 'count' ? <CountResultDetailContent onSwitch={changeMetric} /> : null }
                 
             </Box>
         </Collapse>

--- a/src/components/Simulation/SimulationResultDetailCard.tsx
+++ b/src/components/Simulation/SimulationResultDetailCard.tsx
@@ -36,18 +36,16 @@ const SimulationResultDetailCard: React.FC<{defaultMetric: StatMetric}> = ({ def
         {/* Header to make the Card lager or smaller */}
         <CardActionArea onClick={() => open.value = !open.peek()}>
             <Box display="flex" flexDirection="row" justifyContent="space-between">
-                <Box sx={{flexGrow: 1, px: 1}}>
-                    <Typography variant="body2">{ open.value ? <>&nbsp;</>  : metric.value.title }</Typography>
-                    <Box display="flex" flexDirection="row" alignItems="center">
-                        <Box flexGrow={1}>
-                            <LinearProgress 
-                                variant="determinate"
-                                value={Math.min((totalValue.value / metric.peek().reference) * 100, 100)}
-                                color={(totalValue.value / metric.peek().reference) * 100 > 50 ? 'success' : 'primary'}
-                            />
-                        </Box>
-                    <Typography variant="body2" ml={1}>{metric.peek().unit}</Typography>
+                <Box display="flex" flexDirection="row" alignItems="center" flexGrow={1} pl={1}>
+                <Typography variant="body2" mr={1}>{ open.value ? <>&nbsp;</>  : metric.value.title }</Typography>
+                    <Box flexGrow={1}>
+                        <LinearProgress 
+                            variant="determinate"
+                            value={Math.min((totalValue.value / metric.peek().reference) * 100, 100)}
+                            color={(totalValue.value / metric.peek().reference) * 100 > 50 ? 'success' : 'primary'}
+                        />
                     </Box>
+                <Typography variant="body2" ml={1}>{metric.peek().unit}</Typography>
                 </Box>
                 
                 <IconButton size="small" edge="end" disableRipple>

--- a/src/components/Simulation/SimulationStepSlider.tsx
+++ b/src/components/Simulation/SimulationStepSlider.tsx
@@ -22,7 +22,7 @@ const SimulationStepSlider: React.FC = () => {
             <CardActionArea onClick={() => open.value = !open.peek()}>
             <Box display="flex" flexDirection="row" justifyContent="space-between" ml={1}>
                 <Typography variant={open.value ? 'h6' : 'body2'} my="auto">simuliere Baumwachstum</Typography>
-                <IconButton size="small" onClick={() => open.value = !open.peek()}>
+                <IconButton size="small">
                     { open.value ? <ExpandMore /> : <ExpandLess /> }
                 </IconButton>
             </Box>

--- a/src/components/Simulation/SimulationStepSlider.tsx
+++ b/src/components/Simulation/SimulationStepSlider.tsx
@@ -20,11 +20,11 @@ const SimulationStepSlider: React.FC = () => {
     return <>
         <Box p={open.value ? 0 : 0}>
             <CardActionArea onClick={() => open.value = !open.peek()}>
-            <Box display="flex" flexDirection="row" justifyContent="space-between" ml={1}>
+            <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center" ml={1}>
                 <Typography variant={open.value ? 'h6' : 'body2'} my="auto">simuliere Baumwachstum</Typography>
-                <IconButton size="small">
+                {/* <IconButton size="small"> */}
                     { open.value ? <ExpandMore /> : <ExpandLess /> }
-                </IconButton>
+                {/* </IconButton> */}
             </Box>
             </CardActionArea>
         <Collapse in={open.value}>

--- a/src/components/Simulation/SimulationStepSlider.tsx
+++ b/src/components/Simulation/SimulationStepSlider.tsx
@@ -1,0 +1,26 @@
+import { Mark } from "@mui/base"
+import { Box, Slider, Typography } from "@mui/material"
+import { setSimulationStep, simulationStep } from "../../appState/simulationSignals"
+
+// hard-code some marks
+const marks: Mark[] = [
+    // {value: 5, label: '5'},
+    {value: 10, label: '10 Jahre'},
+    {value: 30, label: '30 Jahre'},
+    {value: 50, label: '50 Jahre'},
+    {value: 80, label: '80 Jahre'},
+]
+
+const SimulationStepSlider: React.FC = () => {
+    return <>
+        <Typography variant="h6">simuliere Baumwachstum</Typography>
+        <Box display="flex" mt={1}>
+            <Typography variant="body1" mr={2}>{simulationStep.value.current}</Typography>
+            <Slider marks={marks} valueLabelDisplay="auto" value={simulationStep.value.current} onChange={(e, value) => setSimulationStep(value as number)}/>
+            <Typography variant="body1" ml={1}>Jahre</Typography>
+        </Box>
+        
+    </>
+}
+
+export default SimulationStepSlider

--- a/src/components/Simulation/SimulationStepSlider.tsx
+++ b/src/components/Simulation/SimulationStepSlider.tsx
@@ -1,6 +1,8 @@
+import { Box, CardActionArea, Collapse, IconButton, Slider, Typography } from "@mui/material"
+import { ExpandMore, ExpandLess } from "@mui/icons-material"
 import { Mark } from "@mui/base"
-import { Box, Slider, Typography } from "@mui/material"
 import { setSimulationStep, simulationStep } from "../../appState/simulationSignals"
+import { useSignal } from "@preact/signals-react"
 
 // hard-code some marks
 const marks: Mark[] = [
@@ -12,14 +14,27 @@ const marks: Mark[] = [
 ]
 
 const SimulationStepSlider: React.FC = () => {
+    // state to handle card state
+    const open = useSignal<boolean>(true)
+
     return <>
-        <Typography variant="h6">simuliere Baumwachstum</Typography>
-        <Box display="flex" mt={1}>
+        <Box p={open.value ? 0 : 0}>
+            <CardActionArea onClick={() => open.value = !open.peek()}>
+            <Box display="flex" flexDirection="row" justifyContent="space-between" ml={1}>
+                <Typography variant={open.value ? 'h6' : 'body2'} my="auto">simuliere Baumwachstum</Typography>
+                <IconButton size="small" onClick={() => open.value = !open.peek()}>
+                    { open.value ? <ExpandMore /> : <ExpandLess /> }
+                </IconButton>
+            </Box>
+            </CardActionArea>
+        <Collapse in={open.value}>
+        <Box display="flex" mt={1} p={1.5}>
             <Typography variant="body1" mr={2}>{simulationStep.value.current}</Typography>
             <Slider marks={marks} valueLabelDisplay="auto" value={simulationStep.value.current} onChange={(e, value) => setSimulationStep(value as number)}/>
             <Typography variant="body1" ml={1}>Jahre</Typography>
         </Box>
-        
+        </Collapse>
+        </Box>
     </>
 }
 

--- a/src/components/TreeLines/TreeLineOverview.tsx
+++ b/src/components/TreeLines/TreeLineOverview.tsx
@@ -7,6 +7,7 @@ const TreeLineOverview: React.FC = () => {
     const currentState = useSignal<string>('count')
     
     return <>
+        { Object.keys(treeTypeStatistics.value).length === 0 ? null : (
         <Box display="flex" justifyContent="space-between" flexDirection="row" alignItems="center" mt={3} mb={1}>
             <Typography variant="h6">Überlick</Typography>
             <FormControl variant="standard">
@@ -16,6 +17,7 @@ const TreeLineOverview: React.FC = () => {
             </Select>
             </FormControl>
         </Box>
+        )}
         { Object.entries(treeTypeStatistics.value).map(([treeType, stats]) => {
             return <Box key={treeType} display="flex" justifyContent="space-between">
                 <Typography variant="body1">{ treeType }</Typography>

--- a/src/components/TreeLines/TreeLineOverview.tsx
+++ b/src/components/TreeLines/TreeLineOverview.tsx
@@ -1,12 +1,34 @@
-import { Box, Typography } from "@mui/material"
+import { Box, FormControl, MenuItem, Select, Typography } from "@mui/material"
 import { treeTypeStatistics } from "../../appState/statisticsSignals"
+import { useSignal } from "@preact/signals-react"
 
 const TreeLineOverview: React.FC = () => {
+    // create a signal to switch the current stats value
+    const currentState = useSignal<string>('count')
+    
     return <>
+        <Box display="flex" justifyContent="space-between" flexDirection="row" alignItems="center" mt={3} mb={1}>
+            <Typography variant="h6">Überlick</Typography>
+            <FormControl variant="standard">
+            <Select size="small" value={currentState.value} onChange={e => currentState.value = e.target.value}>
+                <MenuItem value="count">Anzahl</MenuItem>
+                <MenuItem value="carbon">Kohlenstoff</MenuItem>
+            </Select>
+            </FormControl>
+        </Box>
         { Object.entries(treeTypeStatistics.value).map(([treeType, stats]) => {
             return <Box key={treeType} display="flex" justifyContent="space-between">
                 <Typography variant="body1">{ treeType }</Typography>
-                <Typography variant="body1">{ `${stats.count} Bäume (${Math.floor(stats.countPerHectare)} / ha)` }</Typography>
+                { currentState.value === 'carbon' ? (
+                    <Typography variant="body1">
+                        { `${((stats.totalCarbon || 0) / 1000).toFixed(2)} t  (${(stats.countPerHectare || 0).toFixed(1)} kg / ha)` }
+                    </Typography>
+                ) : null }
+                { currentState.value === 'count' ? (
+                    <Typography variant="body1">
+                        { `${stats.count} Bäume  (${Math.floor(stats.countPerHectare)} / ha)` }
+                    </Typography>
+                ) : null }
             </Box>
         })}
     </>

--- a/src/components/TreeLines/TreeLineOverview.tsx
+++ b/src/components/TreeLines/TreeLineOverview.tsx
@@ -23,7 +23,7 @@ const TreeLineOverview: React.FC = () => {
                 <Typography variant="body1">{ treeType }</Typography>
                 { currentState.value === 'carbon' ? (
                     <Typography variant="body1">
-                        { `${((stats.totalCarbon || 0) / 1000).toFixed(2)} t  (${(stats.countPerHectare || 0).toFixed(1)} kg / ha)` }
+                        { `${((stats.totalCarbon || 0) / 1000).toFixed(2)} t  (${((stats.carbonPerHectare || 0) / 1000).toFixed(1)} t / ha)` }
                     </Typography>
                 ) : null }
                 { currentState.value === 'count' ? (

--- a/src/components/TreeLines/TreeLineOverview.tsx
+++ b/src/components/TreeLines/TreeLineOverview.tsx
@@ -14,6 +14,7 @@ const TreeLineOverview: React.FC = () => {
             <Select size="small" value={currentState.value} onChange={e => currentState.value = e.target.value}>
                 <MenuItem value="count">Anzahl</MenuItem>
                 <MenuItem value="carbon">Kohlenstoff</MenuItem>
+                <MenuItem value="height">Baumhöhe</MenuItem>
             </Select>
             </FormControl>
         </Box>
@@ -31,6 +32,11 @@ const TreeLineOverview: React.FC = () => {
                         { `${stats.count} Bäume  (${Math.floor(stats.countPerHectare)} / ha)` }
                     </Typography>
                 ) : null }
+                { currentState.value === 'height' ? (
+                    <Typography variant="body1">
+                        { `${stats.meanHeight?.toFixed(1)} m  (${stats.meanTruncHeight?.toFixed(1)} m Stamm)` }
+                    </Typography>
+                ) : null}
             </Box>
         })}
     </>

--- a/src/layout/desktop/TreeLineDetailCard.tsx
+++ b/src/layout/desktop/TreeLineDetailCard.tsx
@@ -3,7 +3,7 @@ import { ArrowBack } from "@mui/icons-material"
 
 
 import TreeLineDetails from "../../components/TreeLines/TreeLineDetails"
-import { Box, CircularProgress, IconButton, Typography } from "@mui/material"
+import { Box, IconButton, Typography } from "@mui/material"
 import { treeLines } from "../../appState/treeLineSignals"
 import { useSignal } from "@preact/signals-react"
 import TreeLineActionsButtonGroup from "../../components/TreeLines/TreeLineActionsButtonGroup"

--- a/src/layout/desktop/TreeLineListCard.tsx
+++ b/src/layout/desktop/TreeLineListCard.tsx
@@ -17,10 +17,9 @@ const TreeLineListCard: React.FC = () => {
                 <span />
             </Box>
 
-            <Typography variant="h6" mt="2rem">Überlick</Typography>
             <TreeLineOverview />
             
-            <Box display="flex" justifyContent="space-between" mt="2rem">
+            <Box display="flex" justifyContent="space-between" mt="3rem">
                 <Typography variant="h6" component="div">Meine Baumreihen</Typography>
                 <EnabledAddTreeLineButton />
             </Box>

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Box, Card, Drawer, IconButton, MenuItem, MenuList, Toolbar, Typography } from "@mui/material"
+import { AppBar, Box, Card, Drawer, Grid, IconButton, MenuItem, MenuList, Toolbar, Typography } from "@mui/material"
 import { DarkMode, LightMode, Menu, ArrowBack } from "@mui/icons-material"
 import { Outlet } from "react-router-dom"
 
@@ -96,10 +96,17 @@ const DesktopMain: React.FC = () => {
                 </Box>
 
                 {/* add the statistics card */}
-                <Box minWidth="250px" maxWidth="350px" width="100%" position="fixed" top="70px" right="10px" zIndex="99">
-                    <Card>
-                        <SimulationResultDetailCard defaultMetric="carbon" />
-                    </Card>
+                <Box width="calc(100% - 350px - 10px - 100px)" maxWidth="700px" position="fixed" top="70px" right="0px" zIndex="99" display="flex" flexWrap="wrap" justifyContent="flex-end">
+                    <Box maxWidth="350px" minWidth="280px" flexBasis="33%"  flexGrow={1} mr={1} mb={1}>
+                        <Card>
+                            <SimulationResultDetailCard defaultMetric="carbon" />
+                        </Card>
+                    </Box>
+                    <Box maxWidth="350px" minWidth="280px" flexBasis="33%" flexGrow={1} mr={1} mb={1}>
+                        <Card>
+                            <SimulationResultDetailCard defaultMetric="height" />
+                        </Card>
+                    </Box>
                 </Box>
             </>) : null }
 

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Box, Drawer, IconButton, MenuItem, MenuList, Toolbar, Typography } from "@mui/material"
+import { AppBar, Box, Card, CardContent, Drawer, IconButton, MenuItem, MenuList, Toolbar, Typography } from "@mui/material"
 import { DarkMode, LightMode, Menu, ArrowBack } from "@mui/icons-material"
 import { Outlet } from "react-router-dom"
 
@@ -6,7 +6,7 @@ import { useIntegraTheme, useModeToggler } from "../context/IntegraThemeContext"
 import MainMap from "../components/MainMap/MainMap"
 import DrawControl from "../components/MainMap/DrawControl"
 import TreeLineSource from "../components/MainMap/TreeLineSource"
-import { drawState } from "../appState/treeLineSignals"
+import { drawState, hasData } from "../appState/treeLineSignals"
 import { DrawState } from "../appState/treeLine.model"
 import DesktopContentCard from "../layout/desktop/DesktopContentCard"
 import TreeLineNewCard from "../layout/desktop/TreeLineNewCard"
@@ -15,6 +15,7 @@ import ReferenceAreaSource from "../components/MainMap/ReferenceAreaSource"
 import ProjectSelect from "../components/ProjectSelect"
 import { useSignal } from "@preact/signals-react"
 import MapLayerSwitchButton from "../components/MainMap/MapLayerSwitchButton"
+import SimulationStepSlider from "../components/Simulation/SimulationStepSlider"
 
 
 
@@ -84,6 +85,17 @@ const DesktopMain: React.FC = () => {
                 </DesktopContentCard>
             ) : <Outlet /> }
 
+            {/* Only render the simulation cards if there is data and no editing */}
+            { hasData.value && drawState.value === DrawState.OFF ? (<>
+                {/* add the simulation slider */}
+                <Box minWidth="250px" width="40vw" maxWidth="450px" position="fixed" bottom="25px" left="0" right="0" mx="auto" zIndex="99">
+                    <Card>
+                        <CardContent>
+                            <SimulationStepSlider />
+                        </CardContent>
+                    </Card>
+                </Box>
+            </>) : null }
 
             <MainMap mapId="desktop">
                 <DrawControl />

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -16,6 +16,7 @@ import ProjectSelect from "../components/ProjectSelect"
 import { useSignal } from "@preact/signals-react"
 import MapLayerSwitchButton from "../components/MainMap/MapLayerSwitchButton"
 import SimulationStepSlider from "../components/Simulation/SimulationStepSlider"
+import SimulationResultDetailCard from "../components/Simulation/SimulationResultDetailCard"
 
 
 
@@ -93,6 +94,13 @@ const DesktopMain: React.FC = () => {
                         <CardContent>
                             <SimulationStepSlider />
                         </CardContent>
+                    </Card>
+                </Box>
+
+                {/* add the statistics card */}
+                <Box minWidth="250px" maxWidth="350px" width="100%" position="fixed" top="70px" right="10px" zIndex="99">
+                    <Card>
+                        <SimulationResultDetailCard defaultMetric="carbon" />
                     </Card>
                 </Box>
             </>) : null }

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Box, Card, CardContent, Drawer, IconButton, MenuItem, MenuList, Toolbar, Typography } from "@mui/material"
+import { AppBar, Box, Card, Drawer, IconButton, MenuItem, MenuList, Toolbar, Typography } from "@mui/material"
 import { DarkMode, LightMode, Menu, ArrowBack } from "@mui/icons-material"
 import { Outlet } from "react-router-dom"
 
@@ -91,9 +91,7 @@ const DesktopMain: React.FC = () => {
                 {/* add the simulation slider */}
                 <Box minWidth="250px" width="40vw" maxWidth="450px" position="fixed" bottom="25px" left="0" right="0" mx="auto" zIndex="99">
                     <Card>
-                        {/* <CardContent> */}
-                            <SimulationStepSlider />
-                        {/* </CardContent> */}
+                        <SimulationStepSlider />
                     </Card>
                 </Box>
 

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -91,9 +91,9 @@ const DesktopMain: React.FC = () => {
                 {/* add the simulation slider */}
                 <Box minWidth="250px" width="40vw" maxWidth="450px" position="fixed" bottom="25px" left="0" right="0" mx="auto" zIndex="99">
                     <Card>
-                        <CardContent>
+                        {/* <CardContent> */}
                             <SimulationStepSlider />
-                        </CardContent>
+                        {/* </CardContent> */}
                     </Card>
                 </Box>
 


### PR DESCRIPTION
This PR closes #47 and makes most data we have explorable by implementing a switch into the Statistics card. The switch has to be activated by clicking on the header. I am not 100% happy with that, because you need one click too much. On the other hand, the UI is not flooded with selects....

This PR is build on #45, which means that has to be merged first