### PR TITLE
add layers for planned and harvested trees

### DIFF
--- a/src/appState/backendSignals.ts
+++ b/src/appState/backendSignals.ts
@@ -3,8 +3,6 @@
  * To ease things a bit, I put all the firebase stuff in here as well.
  */
 import { batch, computed, effect, signal } from "@preact/signals-react";
-import cloneDeep from "lodash.clonedeep";
-import { parse } from "papaparse";
 import { createClient } from "@supabase/supabase-js";
 
 // connect to supabase
@@ -197,6 +195,37 @@ supabase.from("full_dataset_json").select('*')
   
   treeData.value = data
 })
+
+
+/**
+ * SHADING DATA
+ */
+
+// define the raw tree shade data point
+interface RawShadeHull {
+  species_id: number;
+  age: number;
+  month: number;
+  pruned: boolean;
+  coordinates: number[][];
+}
+
+interface RawTreeShade {
+  id: number;
+  latin_name: string;
+  age: number;
+  shade_data: RawShadeHull[];
+}
+
+// create a database of shading data
+// this is a private store and there will be a read only signal for building actual shading polygons from it
+// this is meant to be a buffer for shading data, that is updated, whenever a new tree species was loaded
+// to the map
+const rawTreeShadeData = signal<RawTreeShade[]>([]);
+effect(() => {
+  // listen for changes in the existing tree species
+})
+export const treeShadeData = computed<RawTreeShade[]>(() => rawTreeShadeData.value);
 
 
 

--- a/src/components/MainMap/TreeLineSource.tsx
+++ b/src/components/MainMap/TreeLineSource.tsx
@@ -9,7 +9,7 @@ import { fitBounds } from "./MapObservableStore"
 import { canopyLayer, currentSeason } from "../../appState/simulationSignals"
 import { useSignal, useSignalEffect } from "@preact/signals-react"
 import { layerVisibility, zoom } from "../../appState/mapSignals"
-import { calculatedTreeLines, updateTreePosition } from "../../appState/treeLocationSignals"
+import { calculatedTreeLines, futureTreeFeatures, harvestedTreeFeatures, updateTreePosition } from "../../appState/treeLocationSignals"
 import { setDetailId } from "../../appState/sideContentSignals"
 import { ageToSize } from "../../appState/backendSignals"
 
@@ -272,6 +272,33 @@ const TreeLineSource: React.FC = () => {
                 }}
             />
         </Source>
+        {/* Add a source to show the future tree location with a green cross */}
+        <Source id="future-tree-locations" type="geojson" data={{type: 'FeatureCollection', features: futureTreeFeatures.value}} generateId>
+            <Layer id="future-tree-locations" source="future-tree-locations" type="circle"
+                layout={{
+                    'visibility': zoom.value < 14.5 ? 'none' : 'visible',
+                }}
+                paint={{
+                    'circle-color': 'green',
+                    'circle-opacity': 0.5,
+                    'circle-radius': 6
+                }}
+            />
+        </Source>
+        <Source id="harvested-tree-locations" type="geojson" data={{type: 'FeatureCollection', features: harvestedTreeFeatures.value}} generateId>
+            <Layer id="harvested-tree-locations" source="harvested-tree-locations" type="circle"
+                layout={{
+                    'visibility': zoom.value < 14.5 ? 'none' : 'visible',
+                }}
+                paint={{
+                    'circle-color': 'brown',
+                    'circle-opacity': 0.5,
+                    'circle-radius': 6
+                }}
+            />
+        </Source>
+
+
         <Source id="canopy" type="geojson" data={canopyLayer.value} generateId>
             <Layer id="canopy-layer" source="canopy" type="fill" 
                 layout={{'visibility': canopyIsVisible.value ? 'visible' : 'none'}}


### PR DESCRIPTION
Tiny PR that adds the planned trees and harvested trees to the map. Currently only as green and brown circles, until I find two nice symbols. Maybe a cross for planned locations and a tree stump for harvested trees