### PR TITLE
Icon updates

### DIFF
--- a/src/appState/simulationSignals.ts
+++ b/src/appState/simulationSignals.ts
@@ -39,14 +39,14 @@ effect(() => {
 // season
 export const seasonMonth = signal<number>(6)
 
-export type SEASON = "Flowering" | "Summer" | "Autumn" | "Winter"
+export type SEASON = "flowering" | "summer" | "autumn" | "winter"
 export const currentSeason = computed<SEASON>(() => {
     const mon = seasonMonth.value
 
-    if ([12, 1, 2].includes(mon)) return "Winter"
-    if ([3, 4, 5].includes(mon)) return "Flowering"
-    if ([6, 7, 8].includes(mon)) return "Summer"
-    return "Autumn"
+    if ([12, 1, 2].includes(mon)) return "winter"
+    if ([3, 4, 5].includes(mon)) return "flowering"
+    if ([6, 7, 8].includes(mon)) return "summer"
+    return "autumn"
 })
 
 // use a function to go to the next season month to handle the order correctly

--- a/src/appState/treeLine.model.ts
+++ b/src/appState/treeLine.model.ts
@@ -28,7 +28,7 @@ export interface TreeLocationProperties extends Partial<TreeDataPoint> {
     id: string,
     treeLineId?: string,
     treeType: string,
-    treeShape: string
+    icon_abbrev?: string
 }
 
 // define the interface for user-created tree locations

--- a/src/appState/treeLineSignals.ts
+++ b/src/appState/treeLineSignals.ts
@@ -90,7 +90,6 @@ const allTreeLocationFeatures = computed<TreeLocation["features"]>(() => {
                     id: nanoid(12),
                     treeLineId: treeLine.properties.id,
                     treeType: settings.treeType,
-                    treeShape: 'Form1',
 
                     // spread everything here, but use the age from the !settings!
                     ...data,

--- a/src/appState/treeLocationSignals.ts
+++ b/src/appState/treeLocationSignals.ts
@@ -20,7 +20,7 @@ interface RawTreeLocation {
     id: string,
     location: {lat: number, lng: number},
     treeType: string,
-    treeShape: string,
+    icon_abbrev?: string  
     treeLineId: string,
     age: number,
     harvestAge?: number
@@ -50,7 +50,7 @@ export const rawTreeFeatures = computed<TreeLocation["features"]>(() => {
             },
             properties: {
                 treeType: tree.treeType,
-                treeShape: tree.treeShape,
+                icon_abbrev: tree.icon_abbrev,
                 treeLineId: tree.treeLineId,
                 ...loadClosestDataPoint(tree.treeType, tree.age),
                 age: tree.age,
@@ -116,9 +116,10 @@ export const addNewTree = (tree: {location: {lat: number, lng: number}, treeType
     const nextId = `s${rawTreeLocationSeedData.peek().length + 1}`
 
     // get the shape associated to this tree
-    const shape = treeSpecies.peek().find(species => species.latin_name === tree.treeType)!.shape
-    if (!shape) {
-        console.log(`ERROR: addNewTree(${tree.treeType}): no shape found for this treeType`)
+    const icon_abbrev = treeSpecies.peek().find(species => species.latin_name === tree.treeType)!.icon_abbrev
+    if (!icon_abbrev) {
+        console.log(`ERROR: addNewTree('${tree.treeType}'): no icon associated to this treeType`)
+        console.log(treeSpecies.peek())
     }
 
     rawTreeLocationSeedData.value = [
@@ -129,7 +130,7 @@ export const addNewTree = (tree: {location: {lat: number, lng: number}, treeType
             age: editAge.peek(),
             harvestAge: editHarvestAge.peek(),
             treeLineId: editTreeLineId.peek(),
-            treeShape: shape
+            icon_abbrev: icon_abbrev
         }
     ]
 }

--- a/src/components/MainMap/TreeLineSource.tsx
+++ b/src/components/MainMap/TreeLineSource.tsx
@@ -31,7 +31,7 @@ const TreeLineSource: React.FC = () => {
                 ...f,
                 properties: {
                     ...f.properties,
-                    image: `${f.properties.treeShape}_${size}_${season}.png`
+                    image: `${size}_${season}_${f.properties.icon_abbrev}.png`
                 }
             }
         })

--- a/src/components/TreeLines/DraggableTree.tsx
+++ b/src/components/TreeLines/DraggableTree.tsx
@@ -15,7 +15,7 @@ const DraggableTree: React.FC<TreeDropProperties> = ({ treeType, age }) => {
     // get the current source, given the age
     const [src, setSrc] = useState<string>('icons/default-tree.png')
     const [season, setSeason] = useState<SEASON>(currentSeason.peek())
-    const [treeShape, setTreeShape] = useState<string>('Form1')
+    const [iconAbbrev, setIconAbbrev] = useState<string>('')
 
     // listen for changes in the season
     useSignalEffect(() => {
@@ -24,22 +24,22 @@ const DraggableTree: React.FC<TreeDropProperties> = ({ treeType, age }) => {
 
     useEffect(() => {
         // search the list of tree species to figure out the shape
-        const shape = treeSpecies.peek().find(species => species.latin_name === treeType)?.shape || 'Form1'
-        setTreeShape(shape)
+        const icon = treeSpecies.peek().find(species => species.latin_name === treeType)?.icon_abbrev || ''
+        setIconAbbrev(icon)
     }, [treeType, treeIconsLoaded.value])
 
     // listen for changes in the age and treeType
     const updateSrc = useCallback(() => {
         // check if we have a shape
-        if (!treeShape) {
+        if (!iconAbbrev || iconAbbrev === '') {
             setSrc('icons/default-tree.png')
         } else {
             // translate age to size
             const size = ageToSize(age)
-            const newSrc = `${process.env.REACT_APP_SUPABASE_URL}/storage/v1/object/public/icons/${treeShape}_${size}_${season}.png`
+            const newSrc = `${process.env.REACT_APP_SUPABASE_URL}/storage/v1/object/public/icons/${size}_${season}_${iconAbbrev}.png`
             setSrc(newSrc)
         }
-    }, [age, treeShape, season])
+    }, [age, iconAbbrev, season])
 
     useEffect(() => {
         updateSrc()


### PR DESCRIPTION
This PR aligns the Application with the latest changes in the backend. Now, there is a new field called `icon_abbrev`. This is the part of the icon name, that cannot be deducted from the App state. The combination of age-class (s,m,l,xl), season (flowering, summer, autumn, winter) and this abbreviation makes up the correct icon.

Changes to this model should only be done if really, really, necessary as aligning the application is quite error-prone and takes up a lot of development time quite unnecessarily.

With this PR, the two included trees are Bergahorn and Vogelbeere, both with the latest data associated. The shading is also the new data.

@karpaddel, @noobla11 mentioning you for reference here. This is the latest state in terms of shading, tree icons and data.