### PR TITLE
Result area

### DIFF
--- a/src/appState/biomassSimulationSignals.ts
+++ b/src/appState/biomassSimulationSignals.ts
@@ -1,0 +1,54 @@
+/**
+ * This module collects all calculation needed for the biomass result tab
+ * 
+ * Currently this is:
+ *  - the canopy layer
+ */
+
+import { computed } from "@preact/signals-react"
+import { TreeLocationProperties } from "./tree.model"
+import { appView } from "./appViewSignals"
+import { treeLocationFeatures } from "./geoJsonSignals"
+
+import buffer from "@turf/buffer"
+import area from "@turf/area"
+
+// define a model type for canopy
+interface CanopyProperties extends TreeLocationProperties {
+    canopyArea: number,
+    canopyWidth?: number,
+    error?: string
+
+}
+export type Canopy = GeoJSON.FeatureCollection<GeoJSON.Polygon, CanopyProperties>
+
+// now the existence of the 'canopyLayer' can be used to calculate the canopy only conditionally
+export const canopyLayerFeatures = computed<Canopy["features"]>(() => {
+    // if the app view is not on biomass, we don't need a canopy
+    if (appView.value !== 'biomass') {
+        return []
+    } else {
+        // otherwise buffer the treeLocations
+        return treeLocationFeatures.value.map(tree => {
+            // tree buffer defaults to 1m 
+            const buffered = buffer(tree, (tree.properties.canopyWidth || 1) / 2, {units: 'meters'})
+            
+            return {
+                ...buffered,
+                properties: {
+                    ...tree.properties,
+                    canopyArea: area(buffered),
+                    canopyWidth: tree.properties.canopyWidth,
+                    error: !tree.properties.canopyWidth ? `Tree ${tree.properties.id} has no canopy width set` : undefined
+                }
+            }
+        })
+    }
+})
+
+export const canopyLayer = computed<Canopy>(() => {
+    return {
+        type: 'FeatureCollection',
+        features: canopyLayerFeatures.value
+    }
+})

--- a/src/components/MainMap/TreeLineSource.tsx
+++ b/src/components/MainMap/TreeLineSource.tsx
@@ -2,13 +2,14 @@ import { useCallback, useEffect, useState } from "react"
 import { Source, Layer, useMap, MapLayerMouseEvent, MapMouseEvent } from "react-map-gl"
 
 import {  TreeLocation } from "../../appState/tree.model"
-import { canopyLayer, currentSeason } from "../../appState/simulationSignals"
+import { currentSeason } from "../../appState/simulationSignals"
 import { useSignal, useSignalEffect } from "@preact/signals-react"
 import { layerVisibility, zoom } from "../../appState/mapSignals"
 import { updateTreePosition } from "../../appState/treeLocationSignals"
 import { setDetailId } from "../../appState/sideContentSignals"
 import { ageToSize } from "../../appState/backendSignals"
 import { calculatedTreeLines, treeLocations } from "../../appState/geoJsonSignals"
+import { canopyLayer } from "../../appState/biomassSimulationSignals"
 
 const TreeLineSource: React.FC = () => {
     // add a state to track if a tree location is currently dragged

--- a/src/components/Results/BiomassResultCard.tsx
+++ b/src/components/Results/BiomassResultCard.tsx
@@ -1,0 +1,14 @@
+import { Alert, Box } from "@mui/material"
+
+const BiomassResultCard: React.FC = () => {
+    return <>
+        <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center">
+            <img src="empty_state/empty-state-illustration.png" alt="empty state" />
+            <Alert severity="warning">
+                Diese Funktion ist noch in Entwicklung.
+            </Alert>
+        </Box>
+    </>
+}
+
+export default BiomassResultCard

--- a/src/components/Results/BlossomResultCard.tsx
+++ b/src/components/Results/BlossomResultCard.tsx
@@ -1,0 +1,14 @@
+import { Alert, Box } from "@mui/material"
+
+const BlossomResultCard: React.FC = () => {
+    return <>
+        <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center">
+            <img src="empty_state/empty-state-illustration.png" alt="empty state" />
+            <Alert severity="warning">
+                Diese Funktion ist noch in Entwicklung.
+            </Alert>
+        </Box>
+    </>
+}
+
+export default BlossomResultCard

--- a/src/components/Results/InsectResultCard.tsx
+++ b/src/components/Results/InsectResultCard.tsx
@@ -1,0 +1,14 @@
+import { Alert, Box } from "@mui/material"
+
+const InsectResultCard: React.FC = () => {
+    return <>
+        <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center">
+            <img src="empty_state/empty-state-illustration.png" alt="empty state" />
+            <Alert severity="warning">
+                Diese Funktion ist noch in Entwicklung.
+            </Alert>
+        </Box>
+    </>
+}
+
+export default InsectResultCard

--- a/src/components/Results/ResultActionCard.tsx
+++ b/src/components/Results/ResultActionCard.tsx
@@ -13,7 +13,7 @@ const ResultActionCard: React.FC = () => {
     const open = useSignal<boolean>(true)
 
     // finally, if there is no result, we don't render anything
-    if (treeLocationFeatures.value.length === 0 && false) {
+    if (treeLocationFeatures.value.length === 0 && true) {  // set the && true to && false during dev to always show the card
         return <></>
     }
 

--- a/src/components/Results/ResultActionCard.tsx
+++ b/src/components/Results/ResultActionCard.tsx
@@ -1,8 +1,12 @@
-import { Box, Button, Card, CardActionArea, Tab, Tabs, Typography } from "@mui/material"
+import { Box, Button, Card, CardActionArea, Collapse, Tab, Tabs, Typography } from "@mui/material"
 import { treeLocationFeatures } from "../../appState/geoJsonSignals"
 import { AppView, appView } from "../../appState/appViewSignals"
 import { useSignal } from "@preact/signals-react"
 import { ExpandLess, ExpandMore } from "@mui/icons-material"
+import BiomassResultCard from "./BiomassResultCard"
+import ShadeResultCard from "./ShadeResultCard"
+import BlossomResultCard from "./BlossomResultCard"
+import InsectResultCard from "./InsectResultCard"
 
 const ResultActionCard: React.FC = () => {
     // also the Resilt Action Card can be minimized
@@ -42,6 +46,13 @@ const ResultActionCard: React.FC = () => {
                     </Box>
                 </CardActionArea>
             </>)}
+
+            <Collapse in={open.value}>
+                { appView.value === "biomass" ? <BiomassResultCard /> : null }
+                { appView.value === "shade" ? <ShadeResultCard /> : null }
+                { appView.value === "blossoms" ? <BlossomResultCard /> : null }
+                { appView.value === "insects" ? <InsectResultCard /> : null}
+            </Collapse>
 
 
         </Card>

--- a/src/components/Results/ResultActionCard.tsx
+++ b/src/components/Results/ResultActionCard.tsx
@@ -1,0 +1,51 @@
+import { Box, Button, Card, CardActionArea, Tab, Tabs, Typography } from "@mui/material"
+import { treeLocationFeatures } from "../../appState/geoJsonSignals"
+import { AppView, appView } from "../../appState/appViewSignals"
+import { useSignal } from "@preact/signals-react"
+import { ExpandLess, ExpandMore } from "@mui/icons-material"
+
+const ResultActionCard: React.FC = () => {
+    // also the Resilt Action Card can be minimized
+    const open = useSignal<boolean>(true)
+
+    // finally, if there is no result, we don't render anything
+    if (treeLocationFeatures.value.length === 0 && false) {
+        return <></>
+    }
+
+    // otherwise, show stuff
+    return <>
+        <Card sx={{
+            mt: open.value ? '16px' : 0,
+            mr: open.value ? '16px' : 0,
+            p: open.value ? 1 : 1
+        }}>
+            {open.value ? (<>
+                <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center">
+                    <Tabs value={appView.value} onChange={(_, value) => appView.value = value as AppView}>
+                        <Tab label="Biomasse" value="biomass" />
+                        <Tab label="Schatten" value="shade" />
+                        <Tab label="Blüten" value="blossoms" />
+                        <Tab label="Insekten" value="insects" />
+                    </Tabs>
+                    <Button size="small" variant="text" onClick={() => open.value = false}>
+                        <ExpandLess />
+                    </Button>
+                </Box>
+            </>) : (<>
+                <CardActionArea onClick={() => open.value = true}>
+                    <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center" m={0}>
+                        <Typography variant={open.value ? "h6" : "body1"} my="auto">
+                            Übersicht
+                        </Typography>
+                        <ExpandMore />
+                    </Box>
+                </CardActionArea>
+            </>)}
+
+
+        </Card>
+    </>
+}
+
+export default ResultActionCard

--- a/src/components/Results/ShadeResultCard.tsx
+++ b/src/components/Results/ShadeResultCard.tsx
@@ -1,0 +1,14 @@
+import { Alert, Box } from "@mui/material"
+
+const ShadeResultCard: React.FC = () => {
+    return <>
+        <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center">
+            <img src="empty_state/empty-state-illustration.png" alt="empty state" />
+            <Alert severity="warning">
+                Diese Funktion ist noch in Entwicklung.
+            </Alert>
+        </Box>
+    </>
+}
+
+export default ShadeResultCard

--- a/src/components/Simulation/SimulationStepSlider.tsx
+++ b/src/components/Simulation/SimulationStepSlider.tsx
@@ -5,6 +5,7 @@ import { seasonMonth, setSimulationStep, simulationStep } from "../../appState/s
 import { useSignal } from "@preact/signals-react";
 import CircularSlider from "@fseehawer/react-circular-slider";
 import { useEffect, useState } from "react";
+import { appView } from "../../appState/appViewSignals";
 
 // hard-code some marks
 const marks: Mark[] = [
@@ -72,13 +73,17 @@ const SimulationStepSlider: React.FC = () => {
             </CardActionArea>
             <Collapse in={open.value}>
               <Box display="flex" mt={1} p={1} alignItems="center">
+                
                 <Slider
                   marks={marks}
                   valueLabelDisplay="auto"
                   value={simulationStep.value.current}
                   onChange={(e, value) => setSimulationStep(value as number)}
                 />
-                <Box ml={2}>
+
+                {/* The month slider is not needed with the biomass tab open */}
+                { appView.value === 'biomass' ? null :(
+                  <Box ml={2}>
                   <CircularSlider 
                     width={90}
                     label=""
@@ -89,6 +94,8 @@ const SimulationStepSlider: React.FC = () => {
                     labelColor="black"
                   />
                 </Box>
+                )}
+                
               </Box>
             </Collapse>
           </Box>

--- a/src/layout/desktop/ResultContent.tsx
+++ b/src/layout/desktop/ResultContent.tsx
@@ -2,7 +2,7 @@ import { Box } from "@mui/material"
 
 const ResultContent: React.FC<React.PropsWithChildren> = ({ children }) => {
     return <>
-        <Box position="fixed" top="72px" right="0px" zIndex={99} maxWidth="368px" width="25vw" minWidth="329px">
+        <Box position="fixed" top="72px" right="0px" zIndex={99} maxWidth="650px" width="33vw" minWidth="450px">
         { children }
         </Box>
     </>

--- a/src/layout/desktop/ResultContent.tsx
+++ b/src/layout/desktop/ResultContent.tsx
@@ -1,0 +1,11 @@
+import { Box } from "@mui/material"
+
+const ResultContent: React.FC<React.PropsWithChildren> = ({ children }) => {
+    return <>
+        <Box position="fixed" top="72px" right="0px" zIndex={99} maxWidth="368px" width="25vw" minWidth="329px">
+        { children }
+        </Box>
+    </>
+}
+
+export default ResultContent

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -16,6 +16,7 @@ import { simulationIsTouched } from "../appState/simulationSignals";
 import { hasData } from "../appState/geoJsonSignals";
 import MainActionCard from "../components/MainActionCard/MainActionCard";
 import ReferenceAreaSource from "../components/MainMap/ReferenceAreaSource";
+import ResultContent from "../layout/desktop/ResultContent";
 
 const DesktopMain: React.FC = () => {
 
@@ -66,6 +67,10 @@ const DesktopMain: React.FC = () => {
             <TreeLineTooltip />
             <ReferenceAreaSource />
           </MainMap>
+
+          <ResultContent>
+            
+          </ResultContent>
         </Box>
       ) : (
         <Summary />

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -17,6 +17,7 @@ import { hasData } from "../appState/geoJsonSignals";
 import MainActionCard from "../components/MainActionCard/MainActionCard";
 import ReferenceAreaSource from "../components/MainMap/ReferenceAreaSource";
 import ResultContent from "../layout/desktop/ResultContent";
+import ResultActionCard from "../components/Results/ResultActionCard";
 
 const DesktopMain: React.FC = () => {
 
@@ -69,7 +70,7 @@ const DesktopMain: React.FC = () => {
           </MainMap>
 
           <ResultContent>
-            
+            <ResultActionCard />
           </ResultContent>
         </Box>
       ) : (


### PR DESCRIPTION
closes #120 

This PR only implements the control logic to switch the 'appView', when a tab is changed. The single result cards are handled with individual PRs each due to the amount of work.

The Canopy and shading area are now switched by the appView.