### PR TITLE
Layout improvements on Shade result Card

### DIFF
--- a/src/components/Results/ShadeResultCard.tsx
+++ b/src/components/Results/ShadeResultCard.tsx
@@ -23,15 +23,16 @@ const ShadeResultCard: React.FC = () => {
                 <Typography variant="body1" mr={1}>
                     {`Landw. Fläche:    ${(area(agriculturalArea.value) / 10000).toFixed(1)} ha`}
                 </Typography>
-                <Tooltip title="Die landwirtschaftliche Fläche umfasst fie für landwirtschaftliche Zwecke nutzbare Fläche, abzüglich der von Baumstreifen beanspruchten Fläche.">
+                <Tooltip title="Die landwirtschaftliche Fläche umfasst die für landwirtschaftliche Zwecke nutzbare Fläche, abzüglich der von Baumstreifen beanspruchten Fläche.">
                         <Info fontSize="small" color="info" />
                     </Tooltip>
                 </Box>
 
             </Box>
-            <Box p={1} mt={1} display="block" width="100%">
+            <Box p={1} mt={1} mx="auto" display="block">
                 <Plot 
                     layout={{
+                        width: 400,
                         height: 350, 
                         showlegend: true,
                         margin: {t: 0, b: 15},
@@ -39,11 +40,12 @@ const ShadeResultCard: React.FC = () => {
                     }}
                     data={[{
                         type: 'pie',
+                        hole: 0.4,
                         values: [unshadedArea.value, shadedArea.value],
                         labels: ['Unbeschattet', 'Beschattet'],
                         //textinfo: 'label+value+percent',
-                        textinfo: 'label+value',
-                        texttemplate: '%{label}: %{value} ha',
+                        textinfo: 'none',
+                        // texttemplate: '%{label}: %{value} ha',
                         insidetextorientation: 'radial',
                         hovertemplate: '%{customdata[0]}<extra></extra>',
                         customdata: [

--- a/src/components/Results/ShadeResultCard.tsx
+++ b/src/components/Results/ShadeResultCard.tsx
@@ -1,24 +1,61 @@
-import { Box } from "@mui/material"
+import { Box, Tooltip, Typography } from "@mui/material"
 import Plot from "react-plotly.js"
 import { shadeStats } from "../../appState/shadeSimulationSignals"
+import { useComputed } from "@preact/signals-react"
+import { referenceAreaHectar } from "../../appState/referenceAreaSignals"
+import { agriculturalArea } from "../../appState/treeLineSignals"
+import { area } from "@turf/turf"
+import { Info } from "@mui/icons-material"
 
 const ShadeResultCard: React.FC = () => {
+    // calculate the two sizes every time they change
+    const shadedArea = useComputed<number>(() => Math.round(shadeStats.value.shadedArea / 1000) / 10)
+    const unshadedArea = useComputed<number>(() => Math.round((shadeStats.value.agriculturalArea - shadeStats.value.shadedArea) / 1000) / 10)
+    
     return <>
         <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center">
-            <Box p={1}>
+            <Box width="100%" p={1} display="block">
+                <Typography variant="h6">Beschattung der landwirtschaftlichen Fläche</Typography>
+            </Box>
+            <Box width="100%" p={1} mt={2} display="block">
+                <Typography variant="body1">{`Gesamtfläche:     ${referenceAreaHectar.value.toFixed(1)} ha`}</Typography>
+                <Box display="flex" flexDirection="row" alignItems="center">
+                <Typography variant="body1" mr={1}>
+                    {`Landw. Fläche:    ${(area(agriculturalArea.value) / 10000).toFixed(1)} ha`}
+                </Typography>
+                <Tooltip title="Die landwirtschaftliche Fläche umfasst fie für landwirtschaftliche Zwecke nutzbare Fläche, abzüglich der von Baumstreifen beanspruchten Fläche.">
+                        <Info fontSize="small" color="info" />
+                    </Tooltip>
+                </Box>
+
+            </Box>
+            <Box p={1} mt={1} display="block" width="100%">
                 <Plot 
-                    layout={{width: 350, height: 350, title: "Unbeschattete Fläche (ha)", showlegend: false, }}
+                    layout={{
+                        height: 350, 
+                        showlegend: true,
+                        margin: {t: 0, b: 15},
+                        legend: {orientation: 'h'},
+                    }}
                     data={[{
                         type: 'pie',
-                        values: [
-                            ((shadeStats.value.agriculturalArea - shadeStats.value.shadedArea) / 10000).toPrecision(3), 
-                            (shadeStats.value.shadedArea / 10000).toPrecision(3)
-                        ],
+                        values: [unshadedArea.value, shadedArea.value],
                         labels: ['Unbeschattet', 'Beschattet'],
-                        textinfo: 'label+value+percent',
+                        //textinfo: 'label+value+percent',
+                        textinfo: 'label+value',
+                        texttemplate: '%{label}: %{value} ha',
                         insidetextorientation: 'radial',
+                        hovertemplate: '%{customdata[0]}<extra></extra>',
+                        customdata: [
+                            `<b>Unbeschattet</b><br>${unshadedArea.value} ha<br>${(unshadedArea.value / (shadedArea.value + unshadedArea.value) * 100).toFixed(0)}%`, 
+                            `<b>Beschattet</b><br>${shadedArea.value} ha<br>${(shadedArea.value / (shadedArea.value + unshadedArea.value) * 100).toFixed(0)}%`, 
+                        ],
                         marker: {
-                            colors: ['#FFA07A', 'grey']
+                            colors: ['#B4C6E7', '#628ACC'],
+                            line: {
+                                color: 'white',
+                                width: 1
+                            }
                         }
                     }]}
                     config={{displayModeBar: false}}


### PR DESCRIPTION
closes #153 

There are still some layout issues, that I can't figure out how to solve right now. We can either merge anyway, or wait until I find a solution. 

- [ ] Text alignment is slightly off
- [ ] Legend is not horizontal, although it is configured to be (bug in plotly?!)
- [ ] Pie labels sometimes vanish (either a smaller pie, no label at all or a wider Card could solve the issue)