### PR TITLE
Map control - TOP

### DIFF
--- a/src/components/Results/ResultActionCard.tsx
+++ b/src/components/Results/ResultActionCard.tsx
@@ -21,7 +21,7 @@ const ResultActionCard: React.FC = () => {
     return <>
         <Card sx={{
             mt: open.value ? '11px' : 0,
-            mr: open.value ? '45px' : '45px',
+            mr: open.value ? '5px' : '5px',
             p: open.value ? 1 : 1
         }}>
             {open.value ? (<>

--- a/src/components/Results/ResultActionCard.tsx
+++ b/src/components/Results/ResultActionCard.tsx
@@ -20,8 +20,8 @@ const ResultActionCard: React.FC = () => {
     // otherwise, show stuff
     return <>
         <Card sx={{
-            mt: open.value ? '16px' : 0,
-            mr: open.value ? '16px' : 0,
+            mt: open.value ? '11px' : 0,
+            mr: open.value ? '45px' : '45px',
             p: open.value ? 1 : 1
         }}>
             {open.value ? (<>

--- a/src/layout/desktop/ResultContent.tsx
+++ b/src/layout/desktop/ResultContent.tsx
@@ -2,7 +2,7 @@ import { Box } from "@mui/material"
 
 const ResultContent: React.FC<React.PropsWithChildren> = ({ children }) => {
     return <>
-        <Box position="fixed" top="72px" right="0px" zIndex={99} maxWidth="650px" width="33vw" minWidth="450px">
+        <Box position="fixed" top="72px" right="40px" zIndex={99} maxWidth="650px" width="33vw" minWidth="450px">
         { children }
         </Box>
     </>

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -72,7 +72,7 @@ const DesktopMain: React.FC = () => {
           </SideContent>
 
           <MainMap mapId="desktop">
-            <NavigationControl position="bottom-right" visualizePitch />
+            <NavigationControl position="top-right" visualizePitch />
             <TreeLineSource />
             <TreeShadeSource /> 
             <TreeLineTooltip />

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -4,7 +4,6 @@ import {  Summarize, Map } from "@mui/icons-material";
 import MainMap from "../components/MainMap/MainMap";
 import TreeLineSource from "../components/MainMap/TreeLineSource";
 import TreeLineTooltip from "../components/MainMap/TreeLineTooltip";
-import MapLayerSwitchButton from "../components/MainMap/MapLayerSwitchButton";
 import SimulationStepSlider from "../components/Simulation/SimulationStepSlider";
 import SideContent from "../layout/desktop/SideContent";
 import SideTreeDetailCard from "../components/TreeLines/SideTreeDetailCard";
@@ -21,6 +20,7 @@ import { ActivePage, activePage } from "../appState/appViewSignals";
 import { referenceArea } from "../appState/referenceAreaSignals";
 import DistanceMeasurementsSource from "../components/MainMap/DistanceMeasurmentsSource";
 import MapToolsCard from "../components/MapTools/MapToolsCard";
+import { NavigationControl } from "react-map-gl";
 
 const DesktopMain: React.FC = () => {
 
@@ -72,9 +72,9 @@ const DesktopMain: React.FC = () => {
           </SideContent>
 
           <MainMap mapId="desktop">
+            <NavigationControl position="bottom-right" visualizePitch />
             <TreeLineSource />
             <TreeShadeSource /> 
-            <MapLayerSwitchButton />
             <TreeLineTooltip />
             <ReferenceAreaSource />
             <DistanceMeasurementsSource />


### PR DESCRIPTION
@noobla11 @karpaddel 

I added the default mapbox navigation controls to add a north-arrow and close #136. This button comes at 0 implementation cost, but we would have to take it as is. it can also be used to reset the view to north. I also enable the option to visualize the current pitch in arrow, which, however can also be deactivated.

This PR places the controls at theta right corner, which I kind of like. I will open a second PR in a minute, that has an alternative placement, which is also not perfect.