### PR TITLE
Map control - BOTTOM

### DIFF
--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -4,7 +4,6 @@ import {  Summarize, Map } from "@mui/icons-material";
 import MainMap from "../components/MainMap/MainMap";
 import TreeLineSource from "../components/MainMap/TreeLineSource";
 import TreeLineTooltip from "../components/MainMap/TreeLineTooltip";
-import MapLayerSwitchButton from "../components/MainMap/MapLayerSwitchButton";
 import SimulationStepSlider from "../components/Simulation/SimulationStepSlider";
 import SideContent from "../layout/desktop/SideContent";
 import SideTreeDetailCard from "../components/TreeLines/SideTreeDetailCard";
@@ -21,6 +20,7 @@ import { ActivePage, activePage } from "../appState/appViewSignals";
 import { referenceArea } from "../appState/referenceAreaSignals";
 import DistanceMeasurementsSource from "../components/MainMap/DistanceMeasurmentsSource";
 import MapToolsCard from "../components/MapTools/MapToolsCard";
+import { NavigationControl } from "react-map-gl";
 
 const DesktopMain: React.FC = () => {
 
@@ -72,9 +72,9 @@ const DesktopMain: React.FC = () => {
           </SideContent>
 
           <MainMap mapId="desktop">
+            <NavigationControl position="bottom-right" visualizePitch />
             <TreeLineSource />
             <TreeShadeSource /> 
-            <MapLayerSwitchButton />
             <TreeLineTooltip />
             <ReferenceAreaSource />
             <DistanceMeasurementsSource />


### PR DESCRIPTION
This is an alternative to #160 in order to close #136

This one places the controls at the BOTTOM. this way, we do not need to shift the result card and do not waste that much space. I personally dislike this one, as the controls are not placed where you would expect them. Your decision: @noobla11 @karpaddel 

Please choose one option and approve the respective PR and reject the other one...