### PR TITLE
Side Menu and Planungs-Card rework

### DIFF
--- a/src/appState/appViewSignals.ts
+++ b/src/appState/appViewSignals.ts
@@ -31,7 +31,7 @@ export type ActivePage = 'map' | 'summary' | 'glossary'
 export const activePage = signal<ActivePage>('map')
 
 // action card settings
-export type ActiveActionCard = 'none' | 'map-tools' | 'tree-edit' | 'detail'
+export type ActiveActionCard = 'none' | 'map-tools' | 'tree-edit' | 'tree-detail' | 'line-detail'
 const activeActionCard = signal<ActiveActionCard>('tree-edit')
 export const activeCard = computed<ActiveActionCard>(() => activeActionCard.value)
 

--- a/src/appState/appViewSignals.ts
+++ b/src/appState/appViewSignals.ts
@@ -1,6 +1,6 @@
 // These signals will be used to activate or deactivate certain views in the app.
 
-import { signal } from "@preact/signals-react";
+import { computed, signal } from "@preact/signals-react";
 
 export type AppView = 'none' | 'biomass' | 'shade' | 'blossoms' | 'insects'
 // as soon as we can change the 'tabs', go for none initially
@@ -26,9 +26,17 @@ export const removeTreeFromPalette = (treeType: string) => {
     console.log(treePalette.value)
 }
 
+// tab settings
 export type ActivePage = 'map' | 'summary' | 'glossary'
-
 export const activePage = signal<ActivePage>('map')
 
+// action card settings
+export type ActiveActionCard = 'none' | 'map-tools' | 'tree-edit' | 'detail'
+const activeActionCard = signal<ActiveActionCard>('tree-edit')
+export const activeCard = computed<ActiveActionCard>(() => activeActionCard.value)
 
-
+// put the handler into an extra card so that we can manage the behavior of the accordion at one place
+export const handleCardToggle = (card: ActiveActionCard) => {
+    // toogle the card
+    activeActionCard.value = activeActionCard.value === card ? 'none' : card
+}

--- a/src/components/MainActionCard/DraggableElements.tsx
+++ b/src/components/MainActionCard/DraggableElements.tsx
@@ -34,7 +34,7 @@ const DraggableElements: React.FC = () => {
 
             <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center">
                 <Typography sx={{mt: 2}} variant="h6">Angelegte Strukturen</Typography>
-                <Button variant="contained" onClick={() => editTreeLineId.value = nanoid(8)}>Neu</Button>
+                <Button variant="contained" color="success" onClick={() => editTreeLineId.value = nanoid(8)}>Neu</Button>
             </Box>
             <TreeLinesOverview /> 
 

--- a/src/components/MainActionCard/DraggableElements.tsx
+++ b/src/components/MainActionCard/DraggableElements.tsx
@@ -7,6 +7,7 @@ import TreeLinesOverview from "../TreeLines/TreeLinesOverview"
 import { nanoid } from "nanoid"
 import { treePalette } from "../../appState/appViewSignals"
 import DragBox from "./DragBox"
+import { Add  } from "@mui/icons-material"
 
 
 const DraggableElements: React.FC = () => {
@@ -18,6 +19,7 @@ const DraggableElements: React.FC = () => {
 
         <Box display="flex" flexDirection="column" width="100%">
             
+            <Typography variant="h6">Gehölzauswahl</Typography>
             <Box onClick={() => (treeSelectionOpen.value = !treeSelectionOpen.peek())}   sx={{display:'flex', p:1, borderRadius:2, bgcolor:'grey.100', width:'100%'}}>
                 {/* use the tree Palette to fill here */}
                 { treePalette.value.map((tree, idx) => (
@@ -25,13 +27,15 @@ const DraggableElements: React.FC = () => {
                         <DraggableTree treeType={tree} age={editAge.value} />
                     </DragBox>
                 )) }
+                <DragBox>
+                    <Add fontSize="large" style={{color: 'grey', cursor: 'pointer'}} />
+                </DragBox>
             </Box>
 
             <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center">
-                <Typography sx={{mt: 2}} variant="h6">Baumreihen</Typography>
+                <Typography sx={{mt: 2}} variant="h6">Angelegte Strukturen</Typography>
                 <Button variant="contained" onClick={() => editTreeLineId.value = nanoid(8)}>Neu</Button>
             </Box>
-            
             <TreeLinesOverview /> 
 
         </Box>

--- a/src/components/MainActionCard/MainActionCard.tsx
+++ b/src/components/MainActionCard/MainActionCard.tsx
@@ -1,6 +1,6 @@
-import { ExpandLess, ExpandMore } from "@mui/icons-material";
-import { Box, Card, CardActionArea, Collapse, Typography } from "@mui/material";
-import { useSignal, useSignalEffect } from "@preact/signals-react";
+import { ExpandMore } from "@mui/icons-material";
+import { Accordion, AccordionDetails, AccordionSummary, Box, Card, CardActionArea, Collapse, Typography } from "@mui/material";
+import { useSignalEffect } from "@preact/signals-react";
 import ReferenceAreaEditor from "./ReferenceAreaEditor";
 import DraggableElements from "./DraggableElements";
 import { zoom } from "../../appState/mapSignals";
@@ -9,9 +9,6 @@ import { useState } from "react";
 import ZoomBackCard from "./ZoomBackCard";
 
 const MainActionCard: React.FC = () => {
-    // create a signal to track collapsible state of the card
-    const open = useSignal<boolean>(true);
-
     // the main action card toggles between different modes:
     // - finding a location and adding a reference area
     // - adding trees
@@ -34,29 +31,17 @@ const MainActionCard: React.FC = () => {
     })
 
     return <>
-        <Card sx={{
-            p: open.value ? 2 : 1, 
-            marginLeft: open.value ? '16px' : '0px', 
-            //transitionDuration: '800ms',
-            marginTop: open.value ? '16px' : '0px'
-        }}>
-            <CardActionArea onClick={() => (open.value = !open.peek())}>
-                <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center" m={0}>
-                    <Typography variant={open.value ? "h6" : "body1"} my="auto">
-                        {actionMode === 'reference' ?  'Agrarfläche hinzufügen' : 'Bäume hinzufügen' }
-                    </Typography>
-                    { open.value ? <ExpandLess /> : <ExpandMore /> }
-                </Box>
-            </CardActionArea>
+        <Accordion>
+            <AccordionSummary expandIcon={<ExpandMore />}>Meine Planung</AccordionSummary>
 
-            <Collapse in={open.value} sx={{width: '100%'}}>
-                <Box component="div" display="flex" flexDirection="row" mt={1} width="100%">
+            <AccordionDetails>
+                <Box component="div" display="flex" flexDirection="row" width="100%">
                     { actionMode === 'reference' ? <ReferenceAreaEditor /> : null }
                     { actionMode === 'addTree' ? <DraggableElements /> : null }
                     { actionMode === 'zoomIn' ? <ZoomBackCard /> : null }
                 </Box>
-            </Collapse>
-        </Card>
+            </AccordionDetails>
+        </Accordion>
     </>
 }
 

--- a/src/components/MainActionCard/MainActionCard.tsx
+++ b/src/components/MainActionCard/MainActionCard.tsx
@@ -1,6 +1,6 @@
 import { ExpandMore } from "@mui/icons-material";
 import { Accordion, AccordionDetails, AccordionSummary, Box, Card, CardActionArea, Collapse, Typography } from "@mui/material";
-import { useSignalEffect } from "@preact/signals-react";
+import { useSignal, useSignalEffect } from "@preact/signals-react";
 import ReferenceAreaEditor from "./ReferenceAreaEditor";
 import DraggableElements from "./DraggableElements";
 import { zoom } from "../../appState/mapSignals";
@@ -10,6 +10,9 @@ import ZoomBackCard from "./ZoomBackCard";
 import { activeCard, handleCardToggle } from "../../appState/appViewSignals";
 
 const MainActionCard: React.FC = () => {
+    // add a local signal to handle the open state
+    const open = useSignal(true)
+    
     // the main action card toggles between different modes:
     // - finding a location and adding a reference area
     // - adding trees
@@ -33,8 +36,10 @@ const MainActionCard: React.FC = () => {
 
     return <>
         <Accordion 
-            expanded={activeCard.value === 'tree-edit'} 
-            onChange={() => handleCardToggle('tree-edit')}
+            // expanded={activeCard.value === 'tree-edit'} 
+            // onChange={() => handleCardToggle('tree-edit')}
+            expanded={open.value}
+            onChange={() => open.value = !open.peek()}
             disableGutters
         >
             <AccordionSummary expandIcon={<ExpandMore />}>Meine Planung</AccordionSummary>

--- a/src/components/MainActionCard/MainActionCard.tsx
+++ b/src/components/MainActionCard/MainActionCard.tsx
@@ -32,7 +32,11 @@ const MainActionCard: React.FC = () => {
     })
 
     return <>
-        <Accordion expanded={activeCard.value === 'tree-edit'} onChange={() => handleCardToggle('tree-edit')}>
+        <Accordion 
+            expanded={activeCard.value === 'tree-edit'} 
+            onChange={() => handleCardToggle('tree-edit')}
+            disableGutters
+        >
             <AccordionSummary expandIcon={<ExpandMore />}>Meine Planung</AccordionSummary>
 
             <AccordionDetails>

--- a/src/components/MainActionCard/MainActionCard.tsx
+++ b/src/components/MainActionCard/MainActionCard.tsx
@@ -7,6 +7,7 @@ import { zoom } from "../../appState/mapSignals";
 import { referenceArea } from "../../appState/referenceAreaSignals";
 import { useState } from "react";
 import ZoomBackCard from "./ZoomBackCard";
+import { activeCard, handleCardToggle } from "../../appState/appViewSignals";
 
 const MainActionCard: React.FC = () => {
     // the main action card toggles between different modes:
@@ -31,7 +32,7 @@ const MainActionCard: React.FC = () => {
     })
 
     return <>
-        <Accordion>
+        <Accordion expanded={activeCard.value === 'tree-edit'} onChange={() => handleCardToggle('tree-edit')}>
             <AccordionSummary expandIcon={<ExpandMore />}>Meine Planung</AccordionSummary>
 
             <AccordionDetails>

--- a/src/components/MapTools/MapToolsCard.tsx
+++ b/src/components/MapTools/MapToolsCard.tsx
@@ -1,39 +1,16 @@
-import { useSignal } from "@preact/signals-react"
-import { hasData } from "../../appState/geoJsonSignals"
-import { Box, Card, CardActionArea, Collapse, IconButton, Typography } from "@mui/material"
-import { ExpandLess, ExpandMore, FitScreenOutlined } from "@mui/icons-material"
-import MeasureButtons from "./MeasureButtons"
+import { Accordion, AccordionDetails, AccordionSummary, Box, IconButton } from "@mui/material"
+import { ExpandMore, FitScreenOutlined } from "@mui/icons-material"
 import { fitReferenceArea, referenceArea } from "../../appState/referenceAreaSignals"
 
 const MapToolsCard: React.FC = () => {
-    // track if the card is open
-    const open = useSignal<boolean>(true)
-
-    // only show the card at all if there is data
-    //if (!hasData.value) return null
-
-    // render the card
     return <>
-        <Card sx={{
-            mt: open.value ? '16px' : '0px',
-            ml: open.value ? '16px' : '0px',
-            mb: open.value ? '16px' : '0px', 
-            p: open.value ? 2 : 1
-        }}>
-            <CardActionArea onClick={() => open.value = !open.peek()}>
-                <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center" m={0}>
-                    <Typography variant={open.value ? "h6" : "body1"} my="auto">
-                        Kartenwerkzeuge
-                    </Typography>
-                    { open.value ? <ExpandLess /> : <ExpandMore /> }
-                </Box>
-            </CardActionArea>
-
-            <Collapse in={open.value}>
-                <Box sx={{overflowY: 'scroll', p: 1}}>
-                    
+        <Accordion>
+            <AccordionSummary expandIcon={<ExpandMore />}>
+                Kartenwerkzeuge
+            </AccordionSummary>
+            <AccordionDetails>
+                <Box>
                     <Box display="flex" flexDirection="row">
-                        {/* <MeasureButtons /> */}
                         <IconButton 
                             color="primary" 
                             onClick={() => fitReferenceArea()} 
@@ -42,11 +19,9 @@ const MapToolsCard: React.FC = () => {
                             <FitScreenOutlined />
                         </IconButton>
                     </Box>
-                    
                 </Box>
-            </Collapse>
-
-        </Card>
+            </AccordionDetails>
+        </Accordion>
     </>
 }
 

--- a/src/components/MapTools/MapToolsCard.tsx
+++ b/src/components/MapTools/MapToolsCard.tsx
@@ -2,12 +2,18 @@ import { Accordion, AccordionDetails, AccordionSummary, Box, IconButton } from "
 import { ExpandMore, FitScreenOutlined } from "@mui/icons-material"
 import { fitReferenceArea, referenceArea } from "../../appState/referenceAreaSignals"
 import { activeCard, handleCardToggle } from "../../appState/appViewSignals"
+import { useSignal } from "@preact/signals-react"
 
 const MapToolsCard: React.FC = () => {
+    // create a local signal to handle open
+    const open = useSignal(false)
+
     return <>
         <Accordion 
-            expanded={activeCard.value === 'map-tools'} 
-            onChange={() => handleCardToggle('map-tools')}
+            // expanded={activeCard.value === 'map-tools'} 
+            // onChange={() => handleCardToggle('map-tools')}
+            expanded={open.value}
+            onChange={() => open.value = !open.peek()}
             disableGutters
         >
             <AccordionSummary expandIcon={<ExpandMore />}>

--- a/src/components/MapTools/MapToolsCard.tsx
+++ b/src/components/MapTools/MapToolsCard.tsx
@@ -1,10 +1,11 @@
 import { Accordion, AccordionDetails, AccordionSummary, Box, IconButton } from "@mui/material"
 import { ExpandMore, FitScreenOutlined } from "@mui/icons-material"
 import { fitReferenceArea, referenceArea } from "../../appState/referenceAreaSignals"
+import { activeCard, handleCardToggle } from "../../appState/appViewSignals"
 
 const MapToolsCard: React.FC = () => {
     return <>
-        <Accordion>
+        <Accordion expanded={activeCard.value === 'map-tools'} onChange={() => handleCardToggle('map-tools')}>
             <AccordionSummary expandIcon={<ExpandMore />}>
                 Kartenwerkzeuge
             </AccordionSummary>

--- a/src/components/MapTools/MapToolsCard.tsx
+++ b/src/components/MapTools/MapToolsCard.tsx
@@ -5,7 +5,11 @@ import { activeCard, handleCardToggle } from "../../appState/appViewSignals"
 
 const MapToolsCard: React.FC = () => {
     return <>
-        <Accordion expanded={activeCard.value === 'map-tools'} onChange={() => handleCardToggle('map-tools')}>
+        <Accordion 
+            expanded={activeCard.value === 'map-tools'} 
+            onChange={() => handleCardToggle('map-tools')}
+            disableGutters
+        >
             <AccordionSummary expandIcon={<ExpandMore />}>
                 Kartenwerkzeuge
             </AccordionSummary>

--- a/src/components/TreeLines/SideLineDetailCard.tsx
+++ b/src/components/TreeLines/SideLineDetailCard.tsx
@@ -9,6 +9,9 @@ import { flyTo } from "../MainMap/MapObservableStore";
 import { activeCard, handleCardToggle } from "../../appState/appViewSignals";
 
 const SideLineDetailCard: React.FC = () => {
+    // create a local signal to handle open
+    const open = useSignal(true)
+
     // get a copy of the treeline
     const treeLine = useSignal<CalculatedTreeLine["features"][0] | undefined>(undefined)
 
@@ -18,9 +21,9 @@ const SideLineDetailCard: React.FC = () => {
             treeLine.value = calculatedTreeLineFeatures.value.filter(line => line.properties.id === activeTreeLineId.peek())[0]
 
             // if the card is not open, open it
-            if (activeCard.peek() !== 'line-detail') {
-                handleCardToggle('line-detail')
-            }
+            // if (activeCard.peek() !== 'line-detail') {
+            //     handleCardToggle('line-detail')
+            // }
         } else {
             treeLine.value = undefined
         }
@@ -48,8 +51,10 @@ const SideLineDetailCard: React.FC = () => {
 
     return <>
         <Accordion
-            expanded={activeCard.value === 'line-detail'}
-            onChange={() => handleCardToggle('line-detail')}
+            // expanded={activeCard.value === 'line-detail'}
+            // onChange={() => handleCardToggle('line-detail')}
+            expanded={open.value}
+            onChange={() => open.value = !open.peek()}
             disableGutters
         >
             <AccordionSummary expandIcon={<ExpandMore />}>

--- a/src/components/TreeLines/SideLineDetailCard.tsx
+++ b/src/components/TreeLines/SideLineDetailCard.tsx
@@ -2,15 +2,13 @@ import { useSignal, useSignalEffect } from "@preact/signals-react"
 import { CalculatedTreeLine } from "../../appState/tree.model";
 import { activeTreeLineId, setDetailId } from "../../appState/sideContentSignals";
 import { calculatedTreeLineFeatures, updateTreeLineProps } from "../../appState/treeLineSignals";
-import { Box, Card, CardActionArea, Collapse, IconButton, Slider, Typography } from "@mui/material";
-import { Close, ExpandLess, ExpandMore, VisibilityOutlined } from "@mui/icons-material";
+import { Accordion, AccordionActions, AccordionDetails, AccordionSummary, Box, Card, CardActionArea, Collapse, IconButton, Slider, Typography } from "@mui/material";
+import { Close,  ExpandMore, VisibilityOutlined } from "@mui/icons-material";
 import { center } from "@turf/turf";
 import { flyTo } from "../MainMap/MapObservableStore";
+import { activeCard, handleCardToggle } from "../../appState/appViewSignals";
 
 const SideLineDetailCard: React.FC = () => {
-    // state to track if the card is open
-    const open = useSignal<boolean>(true);
-
     // get a copy of the treeline
     const treeLine = useSignal<CalculatedTreeLine["features"][0] | undefined>(undefined)
 
@@ -18,6 +16,11 @@ const SideLineDetailCard: React.FC = () => {
     useSignalEffect(() => {
         if (activeTreeLineId.value) {
             treeLine.value = calculatedTreeLineFeatures.value.filter(line => line.properties.id === activeTreeLineId.peek())[0]
+
+            // if the card is not open, open it
+            if (activeCard.peek() !== 'line-detail') {
+                handleCardToggle('line-detail')
+            }
         } else {
             treeLine.value = undefined
         }
@@ -44,33 +47,17 @@ const SideLineDetailCard: React.FC = () => {
     if (!treeLine.value) return null
 
     return <>
-        <Card sx={{
-            mt: open.value ? '16px' : 0,
-            ml: open.value ? '16px' : 0,
-            p: open.value ? 2 : 1
-        }}>
-            <Box display="flex">
-                <IconButton onClick={handleView} size="small">
-                    <VisibilityOutlined />
-                </IconButton>
+        <Accordion
+            expanded={activeCard.value === 'line-detail'}
+            onChange={() => handleCardToggle('line-detail')}
+            disableGutters
+        >
+            <AccordionSummary expandIcon={<ExpandMore />}>
+                { treeLine.value.properties.name || 'Unbekannte Baumreihe'}
+            </AccordionSummary>
 
-                <CardActionArea onClick={() => open.value = !open.peek()}>
-                    <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center" m={0}>
-                        <Typography variant={open.value ? "h6" : "body1"} my="auto">
-                            { treeLine.value.properties.name || 'Unbekannte Baumreihe'}
-                        </Typography>
-                        { open.value ? <ExpandLess /> : <ExpandMore /> }
-                    </Box>
-                </CardActionArea>
-
-                <IconButton onClick={handleClose} size="small">
-                    <Close />
-                </IconButton>
-            </Box>
-
-            <Collapse in={open.value}>
-                <Box sx={{overflowY: 'scroll', p: 1}}>
-
+            <AccordionDetails>
+                <Box>
                     <Box p={1}>
                         <Box display="flex" flexDirection="row" justifyContent="space-between">
                             <Typography variant="body2">Anzahl Bäume:</Typography>
@@ -101,10 +88,19 @@ const SideLineDetailCard: React.FC = () => {
                             valueLabelDisplay="auto"
                         />
                     </Box>
-
                 </Box>
-            </Collapse>
-        </Card>
+            </AccordionDetails>
+
+            <AccordionActions>
+                <IconButton onClick={handleView} size="small">
+                    <VisibilityOutlined />
+                </IconButton>
+
+                <IconButton onClick={handleClose} size="small">
+                    <Close />
+                </IconButton>
+            </AccordionActions>
+        </Accordion>  
     </>
 }
 

--- a/src/components/TreeLines/SideTreeDetailCard.tsx
+++ b/src/components/TreeLines/SideTreeDetailCard.tsx
@@ -13,21 +13,23 @@ const SideTreeDetailCard: React.FC = () => {
     // get a copy of the tree
     const tree = useSignal<TreeLocation["features"][0] | undefined>(undefined)
 
+    // use a signal to handle the open state locally
+    const open = useSignal(true)
+
     // listen to changes in the activeTreeDetailId signal
     useSignalEffect(() => {
         if (activeTreeDetailId.value) {
             // set the data of the current tree
             tree.value = rawTreeFeatures.value.filter(f => f.id === activeTreeDetailId.peek())[0]
 
-            // if the accordion is not open, open it
-            if (activeCard.peek() !== 'tree-detail') {
-                handleCardToggle('tree-detail')
-            }
+            // // if the accordion is not open, open it
+            // if (activeCard.peek() !== 'tree-detail') {
+            //     handleCardToggle('tree-detail')
+            // }
         } else {
             tree.value = undefined
         }
     })
-
 
     // some card handlers
     const handleClose = () => {
@@ -58,8 +60,10 @@ const SideTreeDetailCard: React.FC = () => {
 
     return <>
         <Accordion 
-            expanded={activeCard.value === 'tree-detail'} 
-            onChange={() => handleCardToggle('tree-detail')}
+            // expanded={activeCard.value === 'tree-detail'} 
+            // onChange={() => handleCardToggle('tree-detail')}
+            expanded={open.value}
+            onChange={() => open.value = !open.peek()}
             disableGutters
         >
             <AccordionSummary expandIcon={<ExpandMore />}>

--- a/src/components/TreeLines/SideTreeDetailCard.tsx
+++ b/src/components/TreeLines/SideTreeDetailCard.tsx
@@ -13,21 +13,6 @@ const SideTreeDetailCard: React.FC = () => {
     // get a copy of the tree
     const tree = useSignal<TreeLocation["features"][0] | undefined>(undefined)
 
-    // For now, we use a mix of pollen, nectar and blossoms, like an overall rating
-    // const pollenRating = useSignal<number>(0)
-    // const nectarRating = useSignal<number>(0)
-    // const blossomsRating = useSignal<number>(0)
-
-    // // for now hard-code the limits, can be requested from supabase one day
-    // useSignalEffect(() => {
-    //     // pollenRating is the relative amount of pollen compared to the max of 140.000.000.000.000, rescaled to 0-5
-    //     pollenRating.value = tree.value?.properties.pollen! / 140000000000000 * 5 || 0
-    //     // nectarRating is the relative amount of nectar compared to the max of 12.000, rescaled to 0-5
-    //     nectarRating.value = tree.value?.properties.nectar! / 12000 * 5 || 0
-    //     //blossomsRating is the relative amount of blossoms compared to the max of 4.000.000, rescaled to 0-5
-    //     blossomsRating.value = tree.value?.properties.blossoms! / 4000000 * 5 || 0
-    // })
-
     // listen to changes in the activeTreeDetailId signal
     useSignalEffect(() => {
         if (activeTreeDetailId.value) {

--- a/src/pages/DesktopMain.tsx
+++ b/src/pages/DesktopMain.tsx
@@ -85,6 +85,7 @@ const DesktopMain: React.FC = () => {
             <SideTreeDetailCard />
             <SideLineDetailCard />
           </SideContent>
+          
 
           <MainMap mapId="desktop">
             <NavigationControl position="bottom-right" visualizePitch />


### PR DESCRIPTION
This is not yet finished.

closes #177 among other things.

This PR makes the sorting and only-one-card-open policy possible and is visually a bit easier to handle. However Action buttons of the tree detail and line detail card are now placed in the default material design action area, below the card, which is not ideal.

@noobla11, can you give me your opinion about the action buttons before I continue here. (The close and eye-button when clicked on a tree or tree line). Placing them back into the header is unfortunately not possible.  That would mean I have to move back to the old cards and see if there is a way how I can implement the desired behavior manually.
With these new cards I can place the buttons manually everywhere **inside** the card, but not the header anymore.